### PR TITLE
fix: use Go 1.13 error wrapping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.33.1
 	github.com/opensearch-project/opensearch-go v1.1.0
-	github.com/pkg/errors v0.9.1
 	github.com/pquerna/otp v1.4.0
 	github.com/prometheus/client_golang v1.19.1
 	github.com/rubenv/sql-migrate v1.6.1
@@ -41,6 +40,7 @@ require (
 	gopkg.in/retry.v1 v1.0.3
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.15.3
+	k8s.io/apimachinery v0.30.2
 	k8s.io/cli-runtime v0.30.0
 	k8s.io/client-go v0.30.2
 )
@@ -138,6 +138,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.2 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
@@ -180,7 +181,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.30.2 // indirect
 	k8s.io/apiextensions-apiserver v0.30.0 // indirect
-	k8s.io/apimachinery v0.30.2 // indirect
 	k8s.io/apiserver v0.30.0 // indirect
 	k8s.io/component-base v0.30.0 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect

--- a/internal/api/v1/converter/app-instance.go
+++ b/internal/api/v1/converter/app-instance.go
@@ -1,23 +1,24 @@
 package converter
 
 import (
+	"fmt"
+
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/chorus"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/app-instance/model"
-	"github.com/pkg/errors"
 )
 
 func AppInstanceToBusiness(appInstance *chorus.AppInstance) (*model.AppInstance, error) {
 	ca, err := FromProtoTimestamp(appInstance.CreatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert createdAt timestamp")
+		return nil, fmt.Errorf("unable to convert createdAt timestamp: %w", err)
 	}
 	ua, err := FromProtoTimestamp(appInstance.UpdatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert updatedAt timestamp")
+		return nil, fmt.Errorf("unable to convert updatedAt timestamp: %w", err)
 	}
 	status, err := model.ToAppInstanceStatus(appInstance.Status)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert appInstance status")
+		return nil, fmt.Errorf("unable to convert appInstance status: %w", err)
 	}
 
 	return &model.AppInstance{
@@ -39,11 +40,11 @@ func AppInstanceToBusiness(appInstance *chorus.AppInstance) (*model.AppInstance,
 func AppInstanceFromBusiness(appInstance *model.AppInstance) (*chorus.AppInstance, error) {
 	ca, err := ToProtoTimestamp(appInstance.CreatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert createdAt timestamp")
+		return nil, fmt.Errorf("unable to convert createdAt timestamp: %w", err)
 	}
 	ua, err := ToProtoTimestamp(appInstance.UpdatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert updatedAt timestamp")
+		return nil, fmt.Errorf("unable to convert updatedAt timestamp: %w", err)
 	}
 
 	return &chorus.AppInstance{

--- a/internal/api/v1/converter/app.go
+++ b/internal/api/v1/converter/app.go
@@ -1,23 +1,24 @@
 package converter
 
 import (
+	"fmt"
+
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/chorus"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/app/model"
-	"github.com/pkg/errors"
 )
 
 func AppToBusiness(app *chorus.App) (*model.App, error) {
 	ca, err := FromProtoTimestamp(app.CreatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert createdAt timestamp")
+		return nil, fmt.Errorf("unable to convert createdAt timestamp: %w", err)
 	}
 	ua, err := FromProtoTimestamp(app.UpdatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert updatedAt timestamp")
+		return nil, fmt.Errorf("unable to convert updatedAt timestamp: %w", err)
 	}
 	status, err := model.ToAppStatus(app.Status)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert app status")
+		return nil, fmt.Errorf("unable to convert app status: %w", err)
 	}
 
 	return &model.App{
@@ -42,11 +43,11 @@ func AppToBusiness(app *chorus.App) (*model.App, error) {
 func AppFromBusiness(app *model.App) (*chorus.App, error) {
 	ca, err := ToProtoTimestamp(app.CreatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert createdAt timestamp")
+		return nil, fmt.Errorf("unable to convert createdAt timestamp: %w", err)
 	}
 	ua, err := ToProtoTimestamp(app.UpdatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert updatedAt timestamp")
+		return nil, fmt.Errorf("unable to convert updatedAt timestamp: %w", err)
 	}
 
 	return &chorus.App{

--- a/internal/api/v1/converter/common.go
+++ b/internal/api/v1/converter/common.go
@@ -1,14 +1,15 @@
 package converter
 
 import (
+	"fmt"
 	"time"
+
+	"github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/chorus"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/common/model"
-	"github.com/golang/protobuf/ptypes/timestamp"
-	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/pkg/errors"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func ToProtoTimestamp(t time.Time) (*timestamp.Timestamp, error) {
@@ -49,7 +50,7 @@ func FromProtoStringDate(t string) (time.Time, error) {
 
 	date, err := time.Parse(time.RFC3339, t)
 	if err != nil {
-		return time.Time{}, errors.Wrap(err, "unable to convert proto string date to time.Time")
+		return time.Time{}, fmt.Errorf("unable to convert proto string date to time.Time: %w", err)
 	}
 	return date, nil
 }

--- a/internal/api/v1/converter/user.go
+++ b/internal/api/v1/converter/user.go
@@ -1,19 +1,20 @@
 package converter
 
 import (
+	"fmt"
+
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/chorus"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/user/model"
-	"github.com/pkg/errors"
 )
 
 func UserFromBusiness(user *model.User) (*chorus.User, error) {
 	ca, err := ToProtoTimestamp(user.CreatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert createdAt timestamp")
+		return nil, fmt.Errorf("unable to convert createdAt timestamp: %w", err)
 	}
 	ua, err := ToProtoTimestamp(user.UpdatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert updatedAt timestamp")
+		return nil, fmt.Errorf("unable to convert updatedAt timestamp: %w", err)
 	}
 
 	var roles []string

--- a/internal/api/v1/converter/workbench.go
+++ b/internal/api/v1/converter/workbench.go
@@ -1,23 +1,24 @@
 package converter
 
 import (
+	"fmt"
+
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/chorus"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/workbench/model"
-	"github.com/pkg/errors"
 )
 
 func WorkbenchToBusiness(workbench *chorus.Workbench) (*model.Workbench, error) {
 	ca, err := FromProtoTimestamp(workbench.CreatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert createdAt timestamp")
+		return nil, fmt.Errorf("unable to convert createdAt timestamp: %w", err)
 	}
 	ua, err := FromProtoTimestamp(workbench.UpdatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert updatedAt timestamp")
+		return nil, fmt.Errorf("unable to convert updatedAt timestamp: %w", err)
 	}
 	status, err := model.ToWorkbenchStatus(workbench.Status)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert workbench status")
+		return nil, fmt.Errorf("unable to convert workbench status: %w", err)
 	}
 
 	return &model.Workbench{
@@ -41,11 +42,11 @@ func WorkbenchToBusiness(workbench *chorus.Workbench) (*model.Workbench, error) 
 func WorkbenchFromBusiness(workbench *model.Workbench) (*chorus.Workbench, error) {
 	ca, err := ToProtoTimestamp(workbench.CreatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert createdAt timestamp")
+		return nil, fmt.Errorf("unable to convert createdAt timestamp: %w", err)
 	}
 	ua, err := ToProtoTimestamp(workbench.UpdatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert updatedAt timestamp")
+		return nil, fmt.Errorf("unable to convert updatedAt timestamp: %w", err)
 	}
 
 	return &chorus.Workbench{

--- a/internal/api/v1/converter/workspace.go
+++ b/internal/api/v1/converter/workspace.go
@@ -1,23 +1,24 @@
 package converter
 
 import (
+	"fmt"
+
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/chorus"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/workspace/model"
-	"github.com/pkg/errors"
 )
 
 func WorkspaceToBusiness(workspace *chorus.Workspace) (*model.Workspace, error) {
 	ca, err := FromProtoTimestamp(workspace.CreatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert createdAt timestamp")
+		return nil, fmt.Errorf("unable to convert createdAt timestamp: %w", err)
 	}
 	ua, err := FromProtoTimestamp(workspace.UpdatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert updatedAt timestamp")
+		return nil, fmt.Errorf("unable to convert updatedAt timestamp: %w", err)
 	}
 	status, err := model.ToWorkspaceStatus(workspace.Status)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert workspace status")
+		return nil, fmt.Errorf("unable to convert workspace status: %w", err)
 	}
 
 	return &model.Workspace{
@@ -40,11 +41,11 @@ func WorkspaceToBusiness(workspace *chorus.Workspace) (*model.Workspace, error) 
 func WorkspaceFromBusiness(workspace *model.Workspace) (*chorus.Workspace, error) {
 	ca, err := ToProtoTimestamp(workspace.CreatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert createdAt timestamp")
+		return nil, fmt.Errorf("unable to convert createdAt timestamp: %w", err)
 	}
 	ua, err := ToProtoTimestamp(workspace.UpdatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert updatedAt timestamp")
+		return nil, fmt.Errorf("unable to convert updatedAt timestamp: %w", err)
 	}
 
 	return &chorus.Workspace{

--- a/internal/api/v1/notification-controller.go
+++ b/internal/api/v1/notification-controller.go
@@ -2,7 +2,12 @@ package v1
 
 import (
 	"context"
+	"fmt"
 	"strings"
+
+	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/chorus"
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/converter"
@@ -10,11 +15,6 @@ import (
 	"github.com/CHORUS-TRE/chorus-backend/internal/utils"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/notification/model"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/notification/service"
-	"github.com/golang/protobuf/ptypes/empty"
-	errors "github.com/pkg/errors"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type NotificationController struct {
@@ -122,11 +122,11 @@ func (c NotificationController) getNotificationToServiceRequest(tenantID, userID
 func notificationFromBusiness(r *model.Notification) (*chorus.Notification, error) {
 	ca, err := converter.ToProtoTimestamp(r.CreatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert createdAt timestamp")
+		return nil, fmt.Errorf("unable to convert createdAt timestamp: %w", err)
 	}
 	ra, err := converter.ToProtoTimestamp(utils.ToTime(r.ReadAt))
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert createdAt timestamp")
+		return nil, fmt.Errorf("unable to convert createdAt timestamp: %w", err)
 	}
 	return &chorus.Notification{
 		Id:        r.ID,

--- a/internal/api/v1/user-controller.go
+++ b/internal/api/v1/user-controller.go
@@ -2,8 +2,11 @@ package v1
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/golang/protobuf/ptypes/empty"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/chorus"
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/converter"
@@ -11,10 +14,6 @@ import (
 	"github.com/CHORUS-TRE/chorus-backend/internal/utils/grpc"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/user/model"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/user/service"
-
-	"github.com/pkg/errors"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // UserController is the user service controller handler.
@@ -279,11 +278,11 @@ func (c UserController) ResetPassword(ctx context.Context, req *chorus.ResetPass
 func userToServiceRequest(user *chorus.User) (*service.UserReq, error) {
 	ca, err := converter.FromProtoTimestamp(user.CreatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert createdAt timestamp")
+		return nil, fmt.Errorf("unable to convert createdAt timestamp: %w", err)
 	}
 	ua, err := converter.FromProtoTimestamp(user.UpdatedAt)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to convert updatedAt timestamp")
+		return nil, fmt.Errorf("unable to convert updatedAt timestamp: %w", err)
 	}
 	userStatus, err := model.ToUserStatus(user.Status)
 	if err != nil {

--- a/internal/client/helm/embed.go
+++ b/internal/client/helm/embed.go
@@ -2,11 +2,11 @@ package helm
 
 import (
 	"embed"
+	"fmt"
 	"io/fs"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	helmloader "helm.sh/helm/v3/pkg/chart/loader"
@@ -42,7 +42,7 @@ func GetHelmChart() (*chart.Chart, error) {
 
 	chart, err := helmloader.LoadFiles(files)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Error loading Helm chart: %v", err)
+		return nil, fmt.Errorf("Error loading Helm chart: %w", err)
 	}
 
 	return chart, err

--- a/internal/cmd/provider/crypto.go
+++ b/internal/cmd/provider/crypto.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/logger"
 	"github.com/CHORUS-TRE/chorus-backend/internal/utils/crypto"
-	"github.com/pkg/errors"
 )
 
 var daemonEncryptionKeyOnce sync.Once
@@ -50,7 +49,7 @@ func loadEncryptionKey(filename string) (*crypto.Secret, error) {
 	//nolint:gosec
 	file, err := os.Open(filename)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to open file %v", filename)
+		return nil, fmt.Errorf("unable to open file %v: %w", filename, err)
 	}
 
 	return loadEncryptionKeyFromReader(file, filename)
@@ -59,7 +58,7 @@ func loadEncryptionKey(filename string) (*crypto.Secret, error) {
 func loadEncryptionKeyFromReader(r io.Reader, filename string) (*crypto.Secret, error) {
 	secretPEM, err := io.ReadAll(r)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to read private key content")
+		return nil, fmt.Errorf("unable to read private key content: %w", err)
 	}
 
 	block, _ := pem.Decode(secretPEM)
@@ -77,7 +76,7 @@ func loadPrivateKey(f string) (*crypto.Secret, error) {
 	//nolint:gosec
 	secretPEM, err := os.ReadFile(f)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to read file %v", f)
+		return nil, fmt.Errorf("unable to read file %v: %w", f, err)
 	}
 
 	block, _ := pem.Decode(secretPEM)

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -14,7 +15,6 @@ import (
 	"github.com/CHORUS-TRE/chorus-backend/internal/protocol/grpc"
 	"github.com/CHORUS-TRE/chorus-backend/internal/protocol/rest"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	google_grpc "google.golang.org/grpc"
@@ -46,7 +46,7 @@ func runServer() error {
 	cfg := provider.ProvideConfig()
 	err := runExportConfig()
 	if err != nil {
-		return errors.Wrap(err, "unable to export config")
+		return fmt.Errorf("unable to export config: %w", err)
 	}
 
 	info := provider.ProvideComponentInfo()

--- a/internal/logger/elasticsearch.go
+++ b/internal/logger/elasticsearch.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/opensearch-project/opensearch-go"
 	"github.com/opensearch-project/opensearch-go/opensearchapi"
-	"github.com/pkg/errors"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/config"
 	"github.com/CHORUS-TRE/chorus-backend/internal/utils/uuid"
@@ -128,7 +127,7 @@ func (f *osFlusher) Flush(entries [][]byte) error {
 	// Perform the request with the client.
 	var res, err = req.Do(ctx, f.client)
 	if err != nil {
-		return errors.Wrap(err, "could not perform opensearch request")
+		return fmt.Errorf("could not perform opensearch request: %w", err)
 	}
 
 	defer func() {
@@ -137,7 +136,7 @@ func (f *osFlusher) Flush(entries [][]byte) error {
 
 	if res.IsError() {
 		_, _ = io.Copy(os.Stderr, res.Body)
-		return errors.Errorf("bulk operation failed: %s", res.Status())
+		return fmt.Errorf("bulk operation failed: %s", res.Status())
 	}
 
 	return nil

--- a/internal/logger/graylog.go
+++ b/internal/logger/graylog.go
@@ -6,11 +6,10 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"os"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/config"
 )
@@ -101,10 +100,10 @@ func (f *gelfFlusher) flush(entries [][]byte) error {
 	var buf bytes.Buffer
 	g := gzip.NewWriter(&buf)
 	if _, err := g.Write(payload); err != nil {
-		return errors.Errorf("ERROR - can't gzip the log payload for Graylog (Write)")
+		return errors.New("ERROR - can't gzip the log payload for Graylog (Write)")
 	}
 	if err := g.Close(); err != nil {
-		return errors.Errorf("ERROR - can't gzip the log payload for Graylog (Close)")
+		return errors.New("ERROR - can't gzip the log payload for Graylog (Close)")
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -2,12 +2,12 @@ package logger
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"sync"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	jack "gopkg.in/natefinch/lumberjack.v2"

--- a/internal/mailer/mailer-service.go
+++ b/internal/mailer/mailer-service.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"html/template"
 	"net"
@@ -12,7 +13,6 @@ import (
 	"strings"
 
 	"github.com/jordan-wright/email"
-	"github.com/pkg/errors"
 )
 
 type Mailer interface {
@@ -37,7 +37,7 @@ func NewMailerService(user, password, authentication string, from map[uint64]str
 
 	host, port, err := net.SplitHostPort(hostPort)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to parse host:port: %v", hostPort)
+		return nil, fmt.Errorf("unable to parse host port: %v: %w", hostPort, err)
 	}
 
 	if strings.ToLower(authentication) != "none" {
@@ -83,7 +83,7 @@ func NewMailerService(user, password, authentication string, from map[uint64]str
 func (m *MailerService) prepare(name, mailTemplate string) error {
 	var tmpl, err = template.New(name).Parse(mailTemplate)
 	if err != nil {
-		return errors.Wrapf(err, "could not prepare template %q", name)
+		return fmt.Errorf("could not prepare template %q: %w", name, err)
 	}
 	m.templates[name] = tmpl
 	return nil
@@ -127,7 +127,7 @@ func (m *MailerService) Send(ctx context.Context, tenantID uint64, to []string, 
 		err = mail.Send(m.hostPort, m.auth)
 	}
 	if err != nil {
-		return errors.Wrapf(err, "could not send mail via %v: from: %v, to: %v, subject: %v", m.hostPort, from, to, subject)
+		return fmt.Errorf("could not send mail via %v: from: %v, to: %v, subject: %v. %w", m.hostPort, from, to, subject, err)
 	}
 
 	return nil

--- a/internal/mailer/middleware/logging.go
+++ b/internal/mailer/middleware/logging.go
@@ -2,13 +2,14 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"html/template"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/CHORUS-TRE/chorus-backend/internal/logger"
 	"github.com/CHORUS-TRE/chorus-backend/internal/mailer"
-	"github.com/pkg/errors"
-	"go.uber.org/zap"
 )
 
 type mailerServiceLogging struct {
@@ -29,7 +30,7 @@ func (c mailerServiceLogging) SendMessage(ctx context.Context, tenantID uint64, 
 			zap.Float64("elapsed_ms", float64(time.Since(now).Nanoseconds())/1000000.0),
 			zap.Uint64("tenant_id", tenantID),
 		)
-		return errors.Wrapf(err, "unable to send message")
+		return fmt.Errorf("unable to send message: %w", err)
 	}
 
 	c.logger.Info(ctx, "message sent",
@@ -54,7 +55,7 @@ func (c mailerServiceLogging) Send(ctx context.Context, tenantID uint64, to []st
 			zap.Float64("elapsed_ms", float64(time.Since(now).Nanoseconds())/1000000.0),
 			zap.Uint64("tenant_id", tenantID),
 		)
-		return errors.Wrapf(err, "unable to send message")
+		return fmt.Errorf("unable to send message: %w", err)
 	}
 
 	c.logger.Info(ctx, "message sent",

--- a/internal/migration/chorus.go
+++ b/internal/migration/chorus.go
@@ -7,8 +7,6 @@ import (
 	"io/fs"
 	"path/filepath"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 const (
@@ -19,14 +17,14 @@ func getMigration(path string) (map[string]string, error) {
 
 	files, err := listMigrationFiles(MigrationEmbed, path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to list '%s' migration files", path)
+		return nil, fmt.Errorf("unable to list %q migration files: %w", path, err)
 	}
 
 	res := map[string]string{}
 	for _, file := range files {
 		content, err := readFile(MigrationEmbed, filePath(path, file))
 		if err != nil {
-			return nil, errors.Wrapf(err, "unable to read embedded file '%s'", file)
+			return nil, fmt.Errorf("unable to read embedded file %q: %w", file, err)
 		}
 		res[removeFileExtension(file)] = content
 	}

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -9,6 +9,7 @@ package migration
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -16,7 +17,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
 	migrate "github.com/rubenv/sql-migrate"
 )
 
@@ -52,7 +52,7 @@ func Migrate(storageType string, migrations map[string]string, migrationTable st
 		logger.TechLog.Error(context.Background(), fmt.Sprintf("unable to execute database migrations (retry: %v). Retrying in 10 seconds", i), zap.Error(err))
 		time.Sleep(10 * time.Second)
 	}
-	return 0, errors.Wrapf(err, "unable to execute database migrations")
+	return 0, fmt.Errorf("unable to execute database migrations: %w", err)
 }
 
 func parseMigration(m map[string]string) (*migrate.MemoryMigrationSource, error) {

--- a/internal/utils/crypto/crypto.go
+++ b/internal/utils/crypto/crypto.go
@@ -5,15 +5,15 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"encoding/base64"
+	"errors"
+	"fmt"
 	"io"
-
-	"github.com/pkg/errors"
 )
 
 func EncryptToString(plaintext []byte, key []byte) (string, error) {
 	e, err := Encrypt(plaintext, key)
 	if err != nil {
-		return "", errors.Wrapf(err, "unable to encrypt plaintext")
+		return "", fmt.Errorf("unable to encrypt plaintext: %w", err)
 	}
 	return base64.StdEncoding.EncodeToString(e), nil
 }
@@ -40,7 +40,7 @@ func Encrypt(plaintext []byte, key []byte) ([]byte, error) {
 func DecryptFromString(ciphertext string, key []byte) ([]byte, error) {
 	c, err := base64.StdEncoding.DecodeString(ciphertext)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to decode base64 encoded ciphertext")
+		return nil, fmt.Errorf("unable to decode base64 encoded ciphertext: %w", err)
 	}
 	return Decrypt(c, key)
 }

--- a/internal/utils/crypto/secret.go
+++ b/internal/utils/crypto/secret.go
@@ -3,11 +3,10 @@ package crypto
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"fmt"
 	"math"
 
 	"golang.org/x/crypto/pbkdf2"
-
-	"github.com/pkg/errors"
 )
 
 type Secret struct {
@@ -20,18 +19,18 @@ func NewSecret(secret []byte) (*Secret, error) {
 
 	key := make([]byte, 32)
 	if _, err := rand.Reader.Read(key); err != nil {
-		return nil, errors.Wrap(err, "unable to generate Key: random reader failed")
+		return nil, fmt.Errorf("unable to generate Key: random reader failed: %w", err)
 	}
 
 	salt := make([]byte, 32)
 	if _, err := rand.Reader.Read(salt); err != nil {
-		return nil, errors.Wrap(err, "unable to generate Salt: random reader failed")
+		return nil, fmt.Errorf("unable to generate Salt: random reader failed: %w", err)
 	}
 	dk := Derive(key, salt)
 	enc, err := Encrypt(secret, dk)
 	Zero(secret)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to encrypt secret")
+		return nil, fmt.Errorf("unable to encrypt secret: %w", err)
 	}
 
 	return &Secret{EncSecret: enc, Key: key, Salt: salt}, nil
@@ -42,7 +41,7 @@ func (k *Secret) Get() ([]byte, error) {
 
 	dec, err := Decrypt(k.EncSecret, dk)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to decrypt seed")
+		return nil, fmt.Errorf("unable to decrypt seed: %w", err)
 	}
 	return dec, nil
 }

--- a/internal/utils/database/database.go
+++ b/internal/utils/database/database.go
@@ -3,10 +3,10 @@ package database
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/logger"
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 

--- a/internal/utils/pagination/cursor.go
+++ b/internal/utils/pagination/cursor.go
@@ -3,8 +3,7 @@ package pagination
 import (
 	"encoding/base64"
 	"encoding/json"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	pb "github.com/CHORUS-TRE/chorus-backend/internal/api/v1/chorus"
 )
@@ -86,10 +85,10 @@ func RequestCursorFromPb[T any](rcPb *pb.RequestCursor) (*RequestCursor[T], erro
 		cursorData = new(T)
 		currentPage, err := base64.StdEncoding.DecodeString(rcPb.CurrentPage)
 		if err != nil {
-			return nil, errors.Wrap(err, "not a valid base64-encoded string")
+			return nil, fmt.Errorf("not a valid base64-encoded string: %w", err)
 		}
 		if err := json.Unmarshal(currentPage, cursorData); err != nil {
-			return nil, errors.Wrap(err, "failed to deserialize data into the target struct")
+			return nil, fmt.Errorf("failed to deserialize data into the target struct: %w", err)
 		}
 	}
 
@@ -123,7 +122,7 @@ func (cursor *ResponseCursor[T]) ToPb() (*pb.ResponseCursor, error) {
 	if cursor.CursorData != nil {
 		currentPageBytes, err := json.Marshal(cursor.CursorData)
 		if err != nil {
-			return responseCursor, errors.Wrap(err, "failed to marshal cursor data as JSON")
+			return responseCursor, fmt.Errorf("failed to marshal cursor data as JSON: %w", err)
 		}
 
 		currentPage = base64.StdEncoding.EncodeToString(currentPageBytes)

--- a/pkg/app-instance/model/app-instance.go
+++ b/pkg/app-instance/model/app-instance.go
@@ -1,9 +1,8 @@
 package model
 
 import (
+	"errors"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // AppInstance maps an entry in the 'app_instances' database table.

--- a/pkg/app-instance/service/middleware/logging.go
+++ b/pkg/app-instance/service/middleware/logging.go
@@ -2,15 +2,15 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/logger"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/app-instance/model"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/app-instance/service"
 	common_model "github.com/CHORUS-TRE/chorus-backend/pkg/common/model"
-
-	"github.com/pkg/errors"
-	"go.uber.org/zap"
 )
 
 type appInstanceServiceLogging struct {
@@ -36,7 +36,7 @@ func (c appInstanceServiceLogging) ListAppInstances(ctx context.Context, tenantI
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return res, errors.Wrapf(err, "unable to get appInstances")
+		return res, fmt.Errorf("unable to get appInstances: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -56,7 +56,7 @@ func (c appInstanceServiceLogging) GetAppInstance(ctx context.Context, tenantID,
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return res, errors.Wrapf(err, "unable to get appInstance")
+		return res, fmt.Errorf("unable to get appInstance: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -76,7 +76,7 @@ func (c appInstanceServiceLogging) DeleteAppInstance(ctx context.Context, tenant
 			logger.WithAppInstanceIDField(appInstanceID),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return errors.Wrapf(err, "unable to delete appInstance")
+		return fmt.Errorf("unable to delete appInstance: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -96,7 +96,7 @@ func (c appInstanceServiceLogging) UpdateAppInstance(ctx context.Context, appIns
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return errors.Wrapf(err, "unable to update appInstance")
+		return fmt.Errorf("unable to update appInstance: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -115,7 +115,7 @@ func (c appInstanceServiceLogging) CreateAppInstance(ctx context.Context, appIns
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return appInstanceId, errors.Wrapf(err, "unable to create appInstance")
+		return appInstanceId, fmt.Errorf("unable to create appInstance: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,

--- a/pkg/app-instance/store/postgres/app-instance-storage.go
+++ b/pkg/app-instance/store/postgres/app-instance-storage.go
@@ -2,13 +2,13 @@ package postgres
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/utils/database"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/app-instance/model"
 	common_model "github.com/CHORUS-TRE/chorus-backend/pkg/common/model"
-
-	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
 )
 
 // AppInstanceStorage is the handler through which a PostgresDB backend can be queried.
@@ -102,11 +102,11 @@ func (s *AppInstanceStorage) DeleteAppInstance(ctx context.Context, tenantID uin
 
 	rows, err := s.db.ExecContext(ctx, query, tenantID, appInstanceID, model.AppInstanceDeleted.String())
 	if err != nil {
-		return errors.Wrap(err, "unable to exec")
+		return fmt.Errorf("unable to exec: %w", err)
 	}
 	affected, err := rows.RowsAffected()
 	if err != nil {
-		return errors.Wrap(err, "unable to get rows affected")
+		return fmt.Errorf("unable to get rows affected: %w", err)
 	}
 
 	if affected == 0 {

--- a/pkg/app/model/app.go
+++ b/pkg/app/model/app.go
@@ -1,9 +1,8 @@
 package model
 
 import (
+	"errors"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // App maps an entry in the 'apps' database table.

--- a/pkg/app/service/app-service.go
+++ b/pkg/app/service/app-service.go
@@ -2,11 +2,10 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/CHORUS-TRE/chorus-backend/pkg/app/model"
 	common_model "github.com/CHORUS-TRE/chorus-backend/pkg/common/model"
-
-	"github.com/pkg/errors"
 )
 
 type Apper interface {
@@ -38,7 +37,7 @@ func NewAppService(store AppStore) *AppService {
 func (u *AppService) ListApps(ctx context.Context, tenantID uint64, pagination common_model.Pagination) ([]*model.App, error) {
 	apps, err := u.store.ListApps(ctx, tenantID, pagination)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to query apps")
+		return nil, fmt.Errorf("unable to query apps: %w", err)
 	}
 	return apps, nil
 }
@@ -46,7 +45,7 @@ func (u *AppService) ListApps(ctx context.Context, tenantID uint64, pagination c
 func (u *AppService) GetApp(ctx context.Context, tenantID, appID uint64) (*model.App, error) {
 	app, err := u.store.GetApp(ctx, tenantID, appID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get app %v", app.ID)
+		return nil, fmt.Errorf("unable to get app %v: %w", app.ID, err)
 	}
 
 	return app, nil
@@ -55,7 +54,7 @@ func (u *AppService) GetApp(ctx context.Context, tenantID, appID uint64) (*model
 func (u *AppService) DeleteApp(ctx context.Context, tenantID, appID uint64) error {
 	err := u.store.DeleteApp(ctx, tenantID, appID)
 	if err != nil {
-		return errors.Wrapf(err, "unable to get app %v", appID)
+		return fmt.Errorf("unable to get app %v, %w", appID, err)
 	}
 
 	return nil
@@ -63,7 +62,7 @@ func (u *AppService) DeleteApp(ctx context.Context, tenantID, appID uint64) erro
 
 func (u *AppService) UpdateApp(ctx context.Context, app *model.App) error {
 	if err := u.store.UpdateApp(ctx, app.TenantID, app); err != nil {
-		return errors.Wrapf(err, "unable to update app %v", app.ID)
+		return fmt.Errorf("unable to update app %v: %w", app.ID, err)
 	}
 
 	return nil
@@ -72,7 +71,7 @@ func (u *AppService) UpdateApp(ctx context.Context, app *model.App) error {
 func (u *AppService) CreateApp(ctx context.Context, app *model.App) (uint64, error) {
 	id, err := u.store.CreateApp(ctx, app.TenantID, app)
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to create app %v", app.Name)
+		return 0, fmt.Errorf("unable to create app %v: %w", app.Name, err)
 	}
 
 	return id, nil

--- a/pkg/app/service/middleware/logging.go
+++ b/pkg/app/service/middleware/logging.go
@@ -2,15 +2,15 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"time"
+
+	"go.uber.org/zap"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/logger"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/app/model"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/app/service"
 	common_model "github.com/CHORUS-TRE/chorus-backend/pkg/common/model"
-
-	"github.com/pkg/errors"
-	"go.uber.org/zap"
 )
 
 type appServiceLogging struct {
@@ -36,7 +36,7 @@ func (c appServiceLogging) ListApps(ctx context.Context, tenantID uint64, pagina
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return res, errors.Wrapf(err, "unable to get apps")
+		return res, fmt.Errorf("unable to get apps: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -56,7 +56,7 @@ func (c appServiceLogging) GetApp(ctx context.Context, tenantID, appID uint64) (
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return res, errors.Wrapf(err, "unable to get app")
+		return res, fmt.Errorf("unable to get app: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -76,7 +76,7 @@ func (c appServiceLogging) DeleteApp(ctx context.Context, tenantID, appID uint64
 			logger.WithAppIDField(appID),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return errors.Wrapf(err, "unable to delete app")
+		return fmt.Errorf("unable to delete app: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -96,7 +96,7 @@ func (c appServiceLogging) UpdateApp(ctx context.Context, app *model.App) error 
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return errors.Wrapf(err, "unable to update app")
+		return fmt.Errorf("unable to update app; %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -115,7 +115,7 @@ func (c appServiceLogging) CreateApp(ctx context.Context, app *model.App) (uint6
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return appId, errors.Wrapf(err, "unable to create app")
+		return appId, fmt.Errorf("unable to create app: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,

--- a/pkg/app/store/postgres/app-storage.go
+++ b/pkg/app/store/postgres/app-storage.go
@@ -2,14 +2,14 @@ package postgres
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/utils/database"
 	"github.com/CHORUS-TRE/chorus-backend/internal/utils/uuid"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/app/model"
 	common_model "github.com/CHORUS-TRE/chorus-backend/pkg/common/model"
-
-	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
 )
 
 // AppStorage is the handler through which a PostgresDB backend can be queried.
@@ -103,11 +103,11 @@ func (s *AppStorage) DeleteApp(ctx context.Context, tenantID uint64, appID uint6
 
 	rows, err := s.db.ExecContext(ctx, query, tenantID, appID, model.AppDeleted.String(), "-"+uuid.Next())
 	if err != nil {
-		return errors.Wrap(err, "unable to exec")
+		return fmt.Errorf("unable to exec: %w", err)
 	}
 	affected, err := rows.RowsAffected()
 	if err != nil {
-		return errors.Wrap(err, "unable to get rows affected")
+		return fmt.Errorf("unable to get rows affected: %w", err)
 	}
 
 	if affected == 0 {

--- a/pkg/authentication/helper/password.go
+++ b/pkg/authentication/helper/password.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/trustelem/zxcvbn"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -31,7 +30,7 @@ func IsStrongPassword(pwd string) bool {
 func HashPass(pass string) (string, error) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.DefaultCost)
 	if err != nil {
-		return "", errors.Wrap(err, "unable to hash password")
+		return "", fmt.Errorf("unable to hash password: %w", err)
 	}
 	return string(hash), nil
 }

--- a/pkg/common/storage/utils.go
+++ b/pkg/common/storage/utils.go
@@ -1,15 +1,16 @@
 package storage
 
 import (
+	"fmt"
+
 	"github.com/jmoiron/sqlx"
 	"github.com/lib/pq"
-	"github.com/pkg/errors"
 )
 
 func Rollback(tx *sqlx.Tx, txErr error) error {
 	rollErr := tx.Rollback()
 	if rollErr != nil {
-		return errors.Wrap(rollErr, txErr.Error())
+		return fmt.Errorf("%s: %w", txErr.Error(), rollErr)
 	}
 	return txErr
 }

--- a/pkg/notification/service/middleware/validation.go
+++ b/pkg/notification/service/middleware/validation.go
@@ -2,12 +2,12 @@ package middleware
 
 import (
 	"context"
+	"fmt"
+
+	val "github.com/go-playground/validator/v10"
 
 	"github.com/CHORUS-TRE/chorus-backend/pkg/notification/model"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/notification/service"
-	"github.com/pkg/errors"
-
-	val "github.com/go-playground/validator/v10"
 )
 
 type validation struct {
@@ -32,7 +32,7 @@ func (v validation) CountUnreadNotifications(ctx context.Context, req service.Co
 }
 func (v validation) MarkNotificationsAsRead(ctx context.Context, req service.MarkNotificationsAsReadRequest) error {
 	if err := v.validate.Struct(req); err != nil {
-		return errors.Wrap(err, "unable to mark notification as read")
+		return fmt.Errorf("unable to mark notification as read: %w", err)
 	}
 	return v.next.MarkNotificationsAsRead(ctx, req)
 }

--- a/pkg/notification/service/notification-service.go
+++ b/pkg/notification/service/notification-service.go
@@ -2,10 +2,10 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	common "github.com/CHORUS-TRE/chorus-backend/pkg/common/model"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/notification/model"
-	"github.com/pkg/errors"
 )
 
 type Notificationer interface {
@@ -33,20 +33,20 @@ func NewNotificationService(store NotificationStore) *NotificationService {
 func (s NotificationService) CountUnreadNotifications(ctx context.Context, req CountUnreadNotificationRequest) (uint32, error) {
 	count, err := s.store.CountUnreadNotifications(ctx, req.TenantID, req.UserID)
 	if err != nil {
-		return 0, errors.Wrap(err, "unable to count unread notifications")
+		return 0, fmt.Errorf("unable to count unread notifications: %w", err)
 	}
 	return count, nil
 }
 func (s NotificationService) MarkNotificationsAsRead(ctx context.Context, req MarkNotificationsAsReadRequest) error {
 	if err := s.store.MarkNotificationsAsRead(ctx, req.TenantID, req.UserID, req.NotificationIDs, req.MarkAll); err != nil {
-		return errors.Wrap(err, "unable to mark notification as read")
+		return fmt.Errorf("unable to mark notification as read: %w", err)
 	}
 	return nil
 }
 func (s NotificationService) GetNotifications(ctx context.Context, req GetNotificationsRequest) ([]*model.Notification, uint32, error) {
 	notifications, count, err := s.store.GetNotifications(ctx, req.TenantID, req.UserID, req.Query, req.IsRead, req.Offset, req.Limit, req.Sort.ToBusinessSort())
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "unable to get notifications")
+		return nil, 0, fmt.Errorf("unable to get notifications: %w", err)
 	}
 	return notifications, count, nil
 }

--- a/pkg/tenant/store/postgres/tenant-storage.go
+++ b/pkg/tenant/store/postgres/tenant-storage.go
@@ -2,10 +2,10 @@ package postgres
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
 
 	"github.com/CHORUS-TRE/chorus-backend/pkg/tenant/model"
 )
@@ -22,7 +22,7 @@ func (s *TenantStorage) GetTenant(ctx context.Context, tenantID uint64) (*model.
 	const q = `SELECT * FROM tenants where id = $1`
 	t := &model.Tenant{}
 	if err := s.db.Get(t, q, tenantID); err != nil {
-		return nil, errors.Wrap(err, "unable to get tenant")
+		return nil, fmt.Errorf("unable to get tenant: %w", err)
 	}
 	return t, nil
 }
@@ -32,5 +32,5 @@ func (s *TenantStorage) CreateTenant(ctx context.Context, tenantID uint64, name 
 		INSERT INTO tenants(id, name, createdat, updatedat) VALUES($1, $2, $3, $3);
 	`
 	_, err := s.db.ExecContext(ctx, ins, tenantID, name, time.Now().UTC())
-	return errors.Wrap(err, "unable to create tenant")
+	return fmt.Errorf("unable to create tenant: %w", err)
 }

--- a/pkg/user/model/role.go
+++ b/pkg/user/model/role.go
@@ -1,6 +1,6 @@
 package model
 
-import "github.com/pkg/errors"
+import "fmt"
 
 // Role maps an entry in the 'roles' database table.
 type Role struct {
@@ -33,7 +33,7 @@ func ToUserRole(role string) (UserRole, error) {
 	case RoleChorus.String():
 		return RoleChorus, nil
 	default:
-		return "", errors.Errorf("unexpected role %v", role)
+		return "", fmt.Errorf("unexpected role %v", role)
 	}
 }
 

--- a/pkg/user/model/user.go
+++ b/pkg/user/model/user.go
@@ -1,9 +1,8 @@
 package model
 
 import (
+	"errors"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // User maps an entry in the 'user' database table.

--- a/pkg/user/service/middleware/logging.go
+++ b/pkg/user/service/middleware/logging.go
@@ -2,13 +2,13 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/logger"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/user/model"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/user/service"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -35,7 +35,7 @@ func (c userServiceLogging) GetUsers(ctx context.Context, req service.GetUsersRe
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return res, errors.Wrapf(err, "unable to get users")
+		return res, fmt.Errorf("unable to get users: %w", err)
 	}
 
 	c.logger.Info(ctx, "request completed",
@@ -55,7 +55,7 @@ func (c userServiceLogging) GetUser(ctx context.Context, req service.GetUserReq)
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return res, errors.Wrapf(err, "unable to get user")
+		return res, fmt.Errorf("unable to get user: %w", err)
 	}
 
 	c.logger.Info(ctx, "request completed",
@@ -75,7 +75,7 @@ func (c userServiceLogging) SoftDeleteUser(ctx context.Context, req service.Dele
 			logger.WithUserIDField(req.ID),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return errors.Wrapf(err, "unable to delete user")
+		return fmt.Errorf("unable to delete user: %w", err)
 	}
 
 	c.logger.Info(ctx, "request completed",
@@ -95,7 +95,7 @@ func (c userServiceLogging) UpdateUser(ctx context.Context, req service.UpdateUs
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return errors.Wrapf(err, "unable to update user")
+		return fmt.Errorf("unable to update user: %w", err)
 	}
 
 	c.logger.Info(ctx, "request completed",
@@ -114,7 +114,7 @@ func (c userServiceLogging) CreateUser(ctx context.Context, req service.CreateUs
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return userId, errors.Wrapf(err, "unable to create user")
+		return userId, fmt.Errorf("unable to create user: %w", err)
 	}
 
 	c.logger.Info(ctx, "request completed",

--- a/pkg/workbench/model/workbench.go
+++ b/pkg/workbench/model/workbench.go
@@ -1,9 +1,8 @@
 package model
 
 import (
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // Workbench maps an entry in the 'workbenchs' database table.
@@ -47,6 +46,6 @@ func ToWorkbenchStatus(status string) (WorkbenchStatus, error) {
 	case WorkbenchDeleted.String():
 		return WorkbenchDeleted, nil
 	default:
-		return "", errors.New("unexpected WorkbenchStatus: " + status)
+		return "", fmt.Errorf("unexpected WorkbenchStatus: %s", status)
 	}
 }

--- a/pkg/workbench/service/middleware/logging.go
+++ b/pkg/workbench/service/middleware/logging.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/CHORUS-TRE/chorus-backend/pkg/workbench/model"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/workbench/service"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -37,7 +37,7 @@ func (c workbenchServiceLogging) ListWorkbenchs(ctx context.Context, tenantID ui
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return res, errors.Wrapf(err, "unable to get workbenchs")
+		return res, fmt.Errorf("unable to get workbenchs: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -56,7 +56,7 @@ func (c workbenchServiceLogging) ProxyWorkbench(ctx context.Context, tenantID, w
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return errors.Wrapf(err, "unable to proxy workbenchs")
+		return fmt.Errorf("unable to proxy workbenchs: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -76,7 +76,7 @@ func (c workbenchServiceLogging) GetWorkbench(ctx context.Context, tenantID, wor
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return res, errors.Wrapf(err, "unable to get workbench")
+		return res, fmt.Errorf("unable to get workbench: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -96,7 +96,7 @@ func (c workbenchServiceLogging) DeleteWorkbench(ctx context.Context, tenantID, 
 			logger.WithWorkbenchIDField(workbenchID),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return errors.Wrapf(err, "unable to delete workbench")
+		return fmt.Errorf("unable to delete workbench: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -116,7 +116,7 @@ func (c workbenchServiceLogging) UpdateWorkbench(ctx context.Context, workbench 
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return errors.Wrapf(err, "unable to update workbench")
+		return fmt.Errorf("unable to update workbench: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -135,7 +135,7 @@ func (c workbenchServiceLogging) CreateWorkbench(ctx context.Context, workbench 
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return workbenchId, errors.Wrapf(err, "unable to create workbench")
+		return workbenchId, fmt.Errorf("unable to create workbench: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,

--- a/pkg/workbench/store/postgres/workbench-storage.go
+++ b/pkg/workbench/store/postgres/workbench-storage.go
@@ -2,14 +2,14 @@ package postgres
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/utils/database"
 	"github.com/CHORUS-TRE/chorus-backend/internal/utils/uuid"
 	common_model "github.com/CHORUS-TRE/chorus-backend/pkg/common/model"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/workbench/model"
-
-	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
 )
 
 // WorkbenchStorage is the handler through which a PostgresDB backend can be queried.
@@ -103,11 +103,11 @@ func (s *WorkbenchStorage) DeleteWorkbench(ctx context.Context, tenantID uint64,
 
 	rows, err := s.db.ExecContext(ctx, query, tenantID, workbenchID, model.WorkbenchDeleted.String(), "-"+uuid.Next())
 	if err != nil {
-		return errors.Wrap(err, "unable to exec")
+		return fmt.Errorf("unable to exec: %w", err)
 	}
 	affected, err := rows.RowsAffected()
 	if err != nil {
-		return errors.Wrap(err, "unable to get rows affected")
+		return fmt.Errorf("unable to get rows affected: %w", err)
 	}
 
 	if affected == 0 {

--- a/pkg/workspace/model/workspace.go
+++ b/pkg/workspace/model/workspace.go
@@ -1,9 +1,8 @@
 package model
 
 import (
+	"fmt"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // Workspace maps an entry in the 'workspaces' database table.
@@ -46,6 +45,6 @@ func ToWorkspaceStatus(status string) (WorkspaceStatus, error) {
 	case WorkspaceDeleted.String():
 		return WorkspaceDeleted, nil
 	default:
-		return "", errors.New("unexpected WorkspaceStatus: " + status)
+		return "", fmt.Errorf("unexpected WorkspaceStatus: %s", status)
 	}
 }

--- a/pkg/workspace/service/middleware/logging.go
+++ b/pkg/workspace/service/middleware/logging.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/logger"
@@ -9,7 +10,6 @@ import (
 	"github.com/CHORUS-TRE/chorus-backend/pkg/workspace/model"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/workspace/service"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )
 
@@ -36,7 +36,7 @@ func (c workspaceServiceLogging) ListWorkspaces(ctx context.Context, tenantID ui
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return res, errors.Wrapf(err, "unable to get workspaces")
+		return res, fmt.Errorf("unable to get workspaces: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -56,7 +56,7 @@ func (c workspaceServiceLogging) GetWorkspace(ctx context.Context, tenantID, wor
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return res, errors.Wrapf(err, "unable to get workspace")
+		return res, fmt.Errorf("unable to get workspace: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -76,7 +76,7 @@ func (c workspaceServiceLogging) DeleteWorkspace(ctx context.Context, tenantID, 
 			logger.WithWorkspaceIDField(workspaceID),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return errors.Wrapf(err, "unable to delete workspace")
+		return fmt.Errorf("unable to delete workspace: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -96,7 +96,7 @@ func (c workspaceServiceLogging) UpdateWorkspace(ctx context.Context, workspace 
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return errors.Wrapf(err, "unable to update workspace")
+		return fmt.Errorf("unable to update workspace: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -115,7 +115,7 @@ func (c workspaceServiceLogging) CreateWorkspace(ctx context.Context, workspace 
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return workspaceId, errors.Wrapf(err, "unable to create workspace")
+		return workspaceId, fmt.Errorf("unable to create workspace: %w", err)
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,

--- a/pkg/workspace/service/workspace-service.go
+++ b/pkg/workspace/service/workspace-service.go
@@ -2,12 +2,11 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/client/helm"
 	common_model "github.com/CHORUS-TRE/chorus-backend/pkg/common/model"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/workspace/model"
-
-	"github.com/pkg/errors"
 )
 
 type Workspaceer interface {
@@ -41,7 +40,7 @@ func NewWorkspaceService(store WorkspaceStore, client helm.HelmClienter) *Worksp
 func (u *WorkspaceService) ListWorkspaces(ctx context.Context, tenantID uint64, pagination common_model.Pagination) ([]*model.Workspace, error) {
 	workspaces, err := u.store.ListWorkspaces(ctx, tenantID, pagination)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to query workspaces")
+		return nil, fmt.Errorf("unable to query workspaces: %w", err)
 	}
 	return workspaces, nil
 }
@@ -49,7 +48,7 @@ func (u *WorkspaceService) ListWorkspaces(ctx context.Context, tenantID uint64, 
 func (u *WorkspaceService) GetWorkspace(ctx context.Context, tenantID, workspaceID uint64) (*model.Workspace, error) {
 	workspace, err := u.store.GetWorkspace(ctx, tenantID, workspaceID)
 	if err != nil {
-		return nil, errors.Wrapf(err, "unable to get workspace %v", workspace.ID)
+		return nil, fmt.Errorf("unable to get workspace %v: %w", workspace.ID, err)
 	}
 
 	return workspace, nil
@@ -58,14 +57,14 @@ func (u *WorkspaceService) GetWorkspace(ctx context.Context, tenantID, workspace
 func (u *WorkspaceService) DeleteWorkspace(ctx context.Context, tenantID, workspaceID uint64) error {
 	err := u.store.DeleteWorkspace(ctx, tenantID, workspaceID)
 	if err != nil {
-		return errors.Wrapf(err, "unable to delete workspace %v", workspaceID)
+		return fmt.Errorf("unable to delete workspace %v: %w", workspaceID, err)
 	}
 
 	// TODO implement delete all workspaces and appInstances
 
 	// err = u.client.DeleteWorkbench(u.getWorkbenchName(workspaceID), u.getWorkbenchName(workspaceID))
 	// if err != nil {
-	// 	return errors.Wrapf(err, "unable to delete workbench %v", workspaceID)
+	// 	return fmt.Errorf("unable to delete workbench %v: %w", workspaceID, err)
 	// }
 
 	return nil
@@ -73,7 +72,7 @@ func (u *WorkspaceService) DeleteWorkspace(ctx context.Context, tenantID, worksp
 
 func (u *WorkspaceService) UpdateWorkspace(ctx context.Context, workspace *model.Workspace) error {
 	if err := u.store.UpdateWorkspace(ctx, workspace.TenantID, workspace); err != nil {
-		return errors.Wrapf(err, "unable to update workspace %v", workspace.ID)
+		return fmt.Errorf("unable to update workspace %v: %w", workspace.ID, err)
 	}
 
 	return nil
@@ -82,14 +81,14 @@ func (u *WorkspaceService) UpdateWorkspace(ctx context.Context, workspace *model
 func (u *WorkspaceService) CreateWorkspace(ctx context.Context, workspace *model.Workspace) (uint64, error) {
 	id, err := u.store.CreateWorkspace(ctx, workspace.TenantID, workspace)
 	if err != nil {
-		return 0, errors.Wrapf(err, "unable to create workspace %v", workspace.ID)
+		return 0, fmt.Errorf("unable to create workspace %v: %w", workspace.ID, err)
 	}
 
 	// should we do something as we can lazily create namespace with helm if needed..?
 
 	// err = u.client.CreateWorkbench(u.getWorkbenchName(id), u.getWorkbenchName(id))
 	// if err != nil {
-	// 	return 0, errors.Wrapf(err, "unable to create workbench %v", workspace.ID)
+	// 	return 0, fmt.Errorf("unable to create workbench %v: %w", workspace.ID, err)
 	// }
 
 	return id, nil

--- a/pkg/workspace/store/postgres/workspace-storage.go
+++ b/pkg/workspace/store/postgres/workspace-storage.go
@@ -2,14 +2,14 @@ package postgres
 
 import (
 	"context"
+	"fmt"
+
+	"github.com/jmoiron/sqlx"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/utils/database"
 	"github.com/CHORUS-TRE/chorus-backend/internal/utils/uuid"
 	common_model "github.com/CHORUS-TRE/chorus-backend/pkg/common/model"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/workspace/model"
-
-	"github.com/jmoiron/sqlx"
-	"github.com/pkg/errors"
 )
 
 // WorkspaceStorage is the handler through which a PostgresDB backend can be queried.
@@ -103,11 +103,11 @@ func (s *WorkspaceStorage) DeleteWorkspace(ctx context.Context, tenantID uint64,
 
 	rows, err := s.db.ExecContext(ctx, query, tenantID, workspaceID, model.WorkspaceDeleted.String(), "-"+uuid.Next())
 	if err != nil {
-		return errors.Wrap(err, "unable to exec")
+		return fmt.Errorf("unable to exec: %w", err)
 	}
 	affected, err := rows.RowsAffected()
 	if err != nil {
-		return errors.Wrap(err, "unable to get rows affected")
+		return fmt.Errorf("unable to get rows affected: %w", err)
 	}
 
 	if affected == 0 {

--- a/tests/helpers/acceptance.go
+++ b/tests/helpers/acceptance.go
@@ -1,10 +1,10 @@
 package helpers
 
 import (
-	"github.com/CHORUS-TRE/chorus-backend/internal/utils/openapi"
-
 	"github.com/go-openapi/runtime"
 	. "github.com/onsi/gomega"
+
+	"github.com/CHORUS-TRE/chorus-backend/internal/utils/openapi"
 )
 
 func ExpectAPIError(expectedErr interface{}) Assertion {


### PR DESCRIPTION
It's still used because Helm uses it, https://github.com/helm/helm/issues/11994

But, the backend doesn't have to use Helm (as far as I know :D).