### PR TITLE
feat: allow adjusting shmSize

### DIFF
--- a/internal/client/helm/chart/templates/workbench.yaml
+++ b/internal/client/helm/chart/templates/workbench.yaml
@@ -9,4 +9,7 @@ spec:
     {{- range .Values.apps }}
     - name: {{ .name }}
       image: {{ .image }}
+      {{- if .shmSize }}
+      shmSize: {{ .shmSize }}
+      {{- end }}
     {{- end }}


### PR DESCRIPTION
If `shmSize` is declared, take into account.

This allows giving extra RAM to the application, which is needed for Jupyter and Vscode.

Based on https://github.com/CHORUS-TRE/workbench-operator/blob/master/config/samples/default_v1alpha1_workbench.yaml#L12-L14

Note: Due to not yet being familiar with this side of the project and having a high workload, I did not have time to test this code suggestion. Please test it before merging @sami-sweng .