### PR TITLE
Improve App image prepulling.

### DIFF
--- a/internal/client/k8s/client.go
+++ b/internal/client/k8s/client.go
@@ -35,7 +35,7 @@ type K8sClienter interface {
 	DeleteAppInstance(namespace, workbenchName string, appInstance AppInstance) error
 	DeleteWorkbench(namespace, workbenchName string) error
 
-	PrePullImageOnAllNodes(image string) error
+	PrePullImageOnAllNodes(image string)
 
 	WatchOnNewWorkbench(func(workbench Workbench) error) error
 	WatchOnUpdateWorkbench(func(workbench Workbench) error) error

--- a/internal/client/k8s/testClient.go
+++ b/internal/client/k8s/testClient.go
@@ -53,6 +53,4 @@ func (c *testClient) DeleteWorkbench(namespace, workbenchName string) error {
 	return nil
 }
 
-func (c *testClient) PrePullImageOnAllNodes(image string) error {
-	return nil
-}
+func (c *testClient) PrePullImageOnAllNodes(image string) {}


### PR DESCRIPTION
* Make K8sClient pre-pull function silent, only logging errors when encountered
* Use an asynchronous goroutine for pre-pulls on app creation and update
* Replace K8sClient logic to use K8s batch Jobs instead of raw pods. This allows to add a TTL duration after completion.