### PR TITLE
Fix workbenchs not being deleted when deleting workspace.

### DIFF
--- a/internal/cmd/provider/workspace.go
+++ b/internal/cmd/provider/workspace.go
@@ -24,6 +24,7 @@ func ProvideWorkspace() service.Workspaceer {
 		workspace = service.NewWorkspaceService(
 			ProvideWorkspaceStore(),
 			ProvideK8sClient(),
+			ProvideWorkbench(),
 		)
 		workspace = service_mw.Logging(logger.BizLog)(workspace)
 		workspace = service_mw.Validation(ProvideValidator())(workspace)

--- a/internal/migration/postgres/00013_delete_workbenchs_from_deleted_workspaces.sql
+++ b/internal/migration/postgres/00013_delete_workbenchs_from_deleted_workspaces.sql
@@ -1,0 +1,28 @@
+-- +migrate Up
+
+-- +migrate StatementBegin
+UPDATE workbenchs
+SET status = 'deleted',
+    updatedat = NOW(),
+    deletedat = NOW()
+WHERE workspaceid IN (
+    SELECT id
+    FROM workspaces
+    WHERE deletedat IS NOT NULL
+)
+AND deletedat IS NULL;
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+UPDATE app_instances
+SET status = 'deleted',
+    updatedat = NOW(),
+    deletedat = NOW()
+WHERE workspaceid IN (
+    SELECT id
+    FROM workspaces
+    WHERE deletedat IS NOT NULL
+)
+AND deletedat IS NULL;
+-- +migrate StatementEnd
+

--- a/pkg/common/storage/utils.go
+++ b/pkg/common/storage/utils.go
@@ -62,8 +62,8 @@ func BuildPaginationClause(pagination *common.Pagination, model common.Sortable)
 	limit := pagination.Limit
 	if pagination.Limit <= 0 || pagination.Limit > common.MAX_LIMIT {
 		limit = common.DEFAULT_LIMIT
-		clause += fmt.Sprintf(" LIMIT %d", limit)
 	}
+	clause += fmt.Sprintf(" LIMIT %d", limit)
 
 	// Add OFFSET clause
 	offset := uint64(0)

--- a/pkg/workbench/service/middleware/caching.go
+++ b/pkg/workbench/service/middleware/caching.go
@@ -71,6 +71,10 @@ func (c *Caching) DeleteWorkbench(ctx context.Context, tenantID, workbenchID uin
 	return c.next.DeleteWorkbench(ctx, tenantID, workbenchID)
 }
 
+func (c *Caching) DeleteWorkbenchsInWorkspace(ctx context.Context, tenantID uint64, workspaceID uint64) error {
+	return c.next.DeleteWorkbenchsInWorkspace(ctx, tenantID, workspaceID)
+}
+
 func (c *Caching) UpdateWorkbench(ctx context.Context, workbench *model.Workbench) (*model.Workbench, error) {
 	return c.next.UpdateWorkbench(ctx, workbench)
 }

--- a/pkg/workbench/service/middleware/logging.go
+++ b/pkg/workbench/service/middleware/logging.go
@@ -106,6 +106,26 @@ func (c workbenchServiceLogging) DeleteWorkbench(ctx context.Context, tenantID, 
 	return nil
 }
 
+func (c workbenchServiceLogging) DeleteWorkbenchsInWorkspace(ctx context.Context, tenantID, workspaceID uint64) error {
+	now := time.Now()
+
+	err := c.next.DeleteWorkbenchsInWorkspace(ctx, tenantID, workspaceID)
+	if err != nil {
+		c.logger.Error(ctx, logger.LoggerMessageRequestFailed,
+			zap.Error(err),
+			logger.WithWorkspaceIDField(workspaceID),
+			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
+		)
+		return fmt.Errorf("unable to delete workbenchs in workspace %v: %w", workspaceID, err)
+	}
+
+	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
+		logger.WithWorkspaceIDField(workspaceID),
+		zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
+	)
+	return nil
+}
+
 func (c workbenchServiceLogging) UpdateWorkbench(ctx context.Context, workbench *model.Workbench) (*model.Workbench, error) {
 	now := time.Now()
 

--- a/pkg/workbench/service/middleware/validation.go
+++ b/pkg/workbench/service/middleware/validation.go
@@ -43,6 +43,10 @@ func (v validation) DeleteWorkbench(ctx context.Context, tenantID, workbenchID u
 	return v.next.DeleteWorkbench(ctx, tenantID, workbenchID)
 }
 
+func (v validation) DeleteWorkbenchsInWorkspace(ctx context.Context, tenantID, workspaceID uint64) error {
+	return v.next.DeleteWorkbenchsInWorkspace(ctx, tenantID, workspaceID)
+}
+
 func (v validation) UpdateWorkbench(ctx context.Context, workbench *model.Workbench) (*model.Workbench, error) {
 	if err := v.validate.Struct(workbench); err != nil {
 		return v.next.UpdateWorkbench(ctx, workbench)

--- a/pkg/workbench/service/workbench-service.go
+++ b/pkg/workbench/service/workbench-service.go
@@ -39,6 +39,7 @@ type Workbencher interface {
 	ProxyWorkbench(ctx context.Context, tenantID, workbenchID uint64, w http.ResponseWriter, r *http.Request) error
 	UpdateWorkbench(ctx context.Context, workbench *model.Workbench) (*model.Workbench, error)
 	DeleteWorkbench(ctx context.Context, tenantId, workbenchId uint64) error
+	DeleteWorkbenchsInWorkspace(ctx context.Context, tenantID uint64, workspaceID uint64) error
 
 	GetAppInstance(ctx context.Context, tenantID, appInstanceID uint64) (*model.AppInstance, error)
 	ListAppInstances(ctx context.Context, tenantID uint64, pagination *common_model.Pagination) ([]*model.AppInstance, *common_model.PaginationResult, error)
@@ -56,6 +57,7 @@ type WorkbenchStore interface {
 	CreateWorkbench(ctx context.Context, tenantID uint64, workbench *model.Workbench) (*model.Workbench, error)
 	UpdateWorkbench(ctx context.Context, tenantID uint64, workbench *model.Workbench) (*model.Workbench, error)
 	DeleteWorkbench(ctx context.Context, tenantID uint64, workbenchID uint64) error
+	DeleteWorkbenchsInWorkspace(ctx context.Context, tenantID uint64, workspaceID uint64) error
 
 	GetAppInstance(ctx context.Context, tenantID uint64, appInstanceID uint64) (*model.AppInstance, error)
 	ListAppInstances(ctx context.Context, tenantID uint64, pagination *common_model.Pagination) ([]*model.AppInstance, *common_model.PaginationResult, error)
@@ -325,6 +327,15 @@ func (s *WorkbenchService) DeleteWorkbench(ctx context.Context, tenantID, workbe
 	err = s.client.DeleteWorkbench(workspace_model.GetWorkspaceClusterName(workbench.WorkspaceID), model.GetWorkbenchClusterName(workbenchID))
 	if err != nil {
 		return fmt.Errorf("unable to delete workbench %v: %w", workbenchID, err)
+	}
+
+	return nil
+}
+
+func (s *WorkbenchService) DeleteWorkbenchsInWorkspace(ctx context.Context, tenantID uint64, workspaceID uint64) error {
+	err := s.store.DeleteWorkbenchsInWorkspace(ctx, tenantID, workspaceID)
+	if err != nil {
+		return fmt.Errorf("unable to delete workbenches in workspace %v: %w", workspaceID, err)
 	}
 
 	return nil

--- a/pkg/workbench/store/middleware/logging.go
+++ b/pkg/workbench/store/middleware/logging.go
@@ -150,6 +150,24 @@ func (c workbenchStorageLogging) DeleteWorkbench(ctx context.Context, tenantID, 
 	return nil
 }
 
+func (c workbenchStorageLogging) DeleteWorkbenchsInWorkspace(ctx context.Context, tenantID uint64, workspaceID uint64) error {
+	c.logger.Debug(ctx, "request started")
+	now := time.Now()
+
+	err := c.next.DeleteWorkbenchsInWorkspace(ctx, tenantID, workspaceID)
+	if err != nil {
+		c.logger.Error(ctx, logger.LoggerMessageRequestFailed,
+			zap.Error(err),
+			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
+		)
+		return err
+	}
+	c.logger.Debug(ctx, "request completed",
+		zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
+	)
+	return nil
+}
+
 func (c workbenchStorageLogging) UpdateWorkbench(ctx context.Context, tenantID uint64, workbench *model.Workbench) (*model.Workbench, error) {
 	c.logger.Debug(ctx, "request started")
 	now := time.Now()

--- a/pkg/workbench/store/postgres/workbench-storage.go
+++ b/pkg/workbench/store/postgres/workbench-storage.go
@@ -206,10 +206,14 @@ func (s *WorkbenchStorage) UpdateWorkbench(ctx context.Context, tenantID uint64,
 }
 
 func (s *WorkbenchStorage) DeleteWorkbench(ctx context.Context, tenantID uint64, workbenchID uint64) error {
+	// First delete app instances in workbench
+	if err := s.DeleteAppInstancesInWorkbench(ctx, tenantID, workbenchID); err != nil {
+		return fmt.Errorf("unable to delete app instances in workbench %v: %w", workbenchID, err)
+	}
+
 	const query = `
-		UPDATE workbenchs	SET 
-			(status, name, updatedat, deletedat) = 
-			($3, concat(name, $4::TEXT), NOW(), NOW())
+		UPDATE workbenchs
+		SET (status, name, updatedat, deletedat) = ($3, concat(name, $4::TEXT), NOW(), NOW())
 		WHERE tenantid = $1 AND id = $2 AND deletedat IS NULL;
 	`
 
@@ -224,6 +228,27 @@ func (s *WorkbenchStorage) DeleteWorkbench(ctx context.Context, tenantID uint64,
 
 	if affected == 0 {
 		return database.ErrNoRowsDeleted
+	}
+
+	return nil
+}
+
+func (s *WorkbenchStorage) DeleteWorkbenchsInWorkspace(ctx context.Context, tenantID uint64, workspaceID uint64) error {
+	const query = `
+		SELECT id FROM workbenchs
+		WHERE tenantid = $1 AND workspaceid = $2 AND status != 'deleted' AND deletedat IS NULL;
+	`
+
+	var workbenchIDs []uint64
+	if err := s.db.SelectContext(ctx, &workbenchIDs, query, tenantID, workspaceID); err != nil {
+		return fmt.Errorf("unable to select workbenchs: %w", err)
+	}
+
+	// Delete workbenchs
+	for _, workbenchID := range workbenchIDs {
+		if err := s.DeleteWorkbench(ctx, tenantID, workbenchID); err != nil {
+			return fmt.Errorf("unable to delete workbench %v: %w", workbenchID, err)
+		}
 	}
 
 	return nil
@@ -359,4 +384,19 @@ func (s *WorkbenchStorage) DeleteAppInstances(ctx context.Context, tenantID uint
 		}
 	}
 	return errors.Join(errAcc...)
+}
+
+func (s *WorkbenchStorage) DeleteAppInstancesInWorkbench(ctx context.Context, tenantID uint64, workbenchID uint64) error {
+	const query = `
+		UPDATE app_instances
+		SET (status, updatedat, deletedat) = ($3, NOW(), NOW())
+		WHERE tenantid = $1 AND workbenchid = $2 AND deletedat IS NULL;
+	`
+
+	_, err := s.db.ExecContext(ctx, query, tenantID, workbenchID, model.AppInstanceDeleted.String())
+	if err != nil {
+		return fmt.Errorf("unable to exec: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/workbench/store/postgres/workbench-storage.go
+++ b/pkg/workbench/store/postgres/workbench-storage.go
@@ -234,6 +234,7 @@ func (s *WorkbenchStorage) DeleteWorkbench(ctx context.Context, tenantID uint64,
 }
 
 func (s *WorkbenchStorage) DeleteWorkbenchsInWorkspace(ctx context.Context, tenantID uint64, workspaceID uint64) error {
+	// TODO: batch
 	const query = `
 		SELECT id FROM workbenchs
 		WHERE tenantid = $1 AND workspaceid = $2 AND status != 'deleted' AND deletedat IS NULL;


### PR DESCRIPTION
* Fix pagination LIMIT clause
* Implement app-instance soft deletion in workbench store when deleting a workbench
* Implement DeleteWorkbenchsInWorkspace in workbench service, middlewares and store
* Use workbench service in workspace service when deleting a workspace
* Add PostgreSQL migration to fix inconsistencies (delete workbenchs and app instances within deleted workspaces)