### PR TITLE
Fix app instance creation using newly created ids.

### DIFF
--- a/pkg/workbench/service/app-instance-service.go
+++ b/pkg/workbench/service/app-instance-service.go
@@ -73,7 +73,7 @@ func (s *WorkbenchService) CreateAppInstance(ctx context.Context, appInstance *m
 	wsName := s.getWorkspaceName(newAppInstance.WorkspaceID)
 	wbName := s.getWorkbenchName(newAppInstance.WorkbenchID)
 
-	clientApp, err := s.getK8sAppInstance(appInstance.TenantID, appInstance.AppID, appInstance.ID)
+	clientApp, err := s.getK8sAppInstance(newAppInstance.TenantID, newAppInstance.AppID, newAppInstance.ID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get app %v: %w", newAppInstance.ID, err)
 	}


### PR DESCRIPTION
* Use correct ids from newly created AppInstance instead of request fields.