### PR TITLE
feat: implement custom chorus errors in workspace file service

### DIFF
--- a/internal/api/v1/workspace-file-controller.go
+++ b/internal/api/v1/workspace-file-controller.go
@@ -6,11 +6,8 @@ import (
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/chorus"
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/converter"
 	"github.com/CHORUS-TRE/chorus-backend/internal/client/filestore"
-	"github.com/CHORUS-TRE/chorus-backend/internal/utils/grpc"
+	cerr "github.com/CHORUS-TRE/chorus-backend/internal/errors"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/workspace-file/service"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var _ chorus.WorkspaceFileServiceServer = (*WorkspaceFileController)(nil)
@@ -27,39 +24,37 @@ func NewWorkspaceFileController(workspaceFile service.WorkspaceFiler) WorkspaceF
 
 func (c WorkspaceFileController) GetWorkspaceFile(ctx context.Context, req *chorus.GetWorkspaceFileRequest) (*chorus.GetWorkspaceFileReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	file, err := c.workspaceFile.GetWorkspaceFile(ctx, req.WorkspaceId, req.Path)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'GetWorkspaceFile': %v", err.Error())
+		return nil, err
 	}
 
 	tgFile, err := converter.WorkspaceFileFromBusiness(file)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
 	}
 
-	resp := &chorus.GetWorkspaceFileReply{Result: &chorus.GetWorkspaceFileResult{File: tgFile}}
-
-	return resp, nil
+	return &chorus.GetWorkspaceFileReply{Result: &chorus.GetWorkspaceFileResult{File: tgFile}}, nil
 }
 
 func (c WorkspaceFileController) ListWorkspaceFiles(ctx context.Context, req *chorus.ListWorkspaceFilesRequest) (*chorus.ListWorkspaceFilesReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	files, err := c.workspaceFile.ListWorkspaceFiles(ctx, req.WorkspaceId, req.Path)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'ListWorkspaceFiles at path %s': %v", req.Path, err.Error())
+		return nil, err
 	}
 
 	tgFiles := make([]*chorus.WorkspaceFile, 0, len(files))
 	for _, file := range files {
 		tgFile, err := converter.WorkspaceFileFromBusiness(file)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+			return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
 		}
 		tgFiles = append(tgFiles, tgFile)
 	}
@@ -69,22 +64,22 @@ func (c WorkspaceFileController) ListWorkspaceFiles(ctx context.Context, req *ch
 
 func (c WorkspaceFileController) CreateWorkspaceFile(ctx context.Context, req *chorus.CreateWorkspaceFileRequest) (*chorus.CreateWorkspaceFileReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	file, err := converter.WorkspaceFileToBusiness(req.File)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
 	}
 
 	newFile, err := c.workspaceFile.CreateWorkspaceFile(ctx, req.WorkspaceId, file)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'CreateWorkspaceFile': %v", err.Error())
+		return nil, err
 	}
 
 	tgFile, err := converter.WorkspaceFileFromBusiness(newFile)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
 	}
 
 	return &chorus.CreateWorkspaceFileReply{Result: &chorus.CreateWorkspaceFileResult{File: tgFile}}, nil
@@ -92,22 +87,22 @@ func (c WorkspaceFileController) CreateWorkspaceFile(ctx context.Context, req *c
 
 func (c WorkspaceFileController) UpdateWorkspaceFile(ctx context.Context, req *chorus.UpdateWorkspaceFileRequest) (*chorus.UpdateWorkspaceFileReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	file, err := converter.WorkspaceFileToBusiness(req.File)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
 	}
 
 	updatedFile, err := c.workspaceFile.UpdateWorkspaceFile(ctx, req.WorkspaceId, req.OldPath, file)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'UpdateWorkspaceFile': %v", err.Error())
+		return nil, err
 	}
 
 	tgFile, err := converter.WorkspaceFileFromBusiness(updatedFile)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
 	}
 
 	return &chorus.UpdateWorkspaceFileReply{Result: &chorus.UpdateWorkspaceFileResult{File: tgFile}}, nil
@@ -115,12 +110,12 @@ func (c WorkspaceFileController) UpdateWorkspaceFile(ctx context.Context, req *c
 
 func (c WorkspaceFileController) DeleteWorkspaceFile(ctx context.Context, req *chorus.DeleteWorkspaceFileRequest) (*chorus.DeleteWorkspaceFileReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	err := c.workspaceFile.DeleteWorkspaceFile(ctx, req.WorkspaceId, req.Path)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'DeleteWorkspaceFile': %v", err.Error())
+		return nil, err
 	}
 
 	return &chorus.DeleteWorkspaceFileReply{Result: &chorus.DeleteWorkspaceFileResult{}}, nil
@@ -128,17 +123,17 @@ func (c WorkspaceFileController) DeleteWorkspaceFile(ctx context.Context, req *c
 
 func (c WorkspaceFileController) InitiateWorkspaceFileUpload(ctx context.Context, req *chorus.InitiateWorkspaceFileUploadRequest) (*chorus.InitiateWorkspaceFileUploadReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	file, err := converter.WorkspaceFileToBusiness(req.File)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
 	}
 
 	uploadInfo, err := c.workspaceFile.InitiateWorkspaceFileUpload(ctx, req.WorkspaceId, req.Path, file)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'InitiateWorkspaceFileUpload': %v", err.Error())
+		return nil, err
 	}
 
 	return &chorus.InitiateWorkspaceFileUploadReply{Result: &chorus.InitiateWorkspaceFileUploadResult{
@@ -150,22 +145,22 @@ func (c WorkspaceFileController) InitiateWorkspaceFileUpload(ctx context.Context
 
 func (c WorkspaceFileController) UploadWorkspaceFilePart(ctx context.Context, req *chorus.UploadWorkspaceFilePartRequest) (*chorus.UploadWorkspaceFilePartReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	filePart, err := converter.WorkspaceFilePartToBusiness(req.Part)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file part")
 	}
 
 	uploadedPart, err := c.workspaceFile.UploadWorkspaceFilePart(ctx, req.WorkspaceId, req.Path, req.UploadId, filePart)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'UploadWorkspaceFilePart': %v", err.Error())
+		return nil, err
 	}
 
 	part, err := converter.WorkspaceFilePartFromBusiness(uploadedPart)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file part")
 	}
 
 	return &chorus.UploadWorkspaceFilePartReply{Result: &chorus.UploadWorkspaceFilePartResult{Part: part}}, nil
@@ -173,26 +168,26 @@ func (c WorkspaceFileController) UploadWorkspaceFilePart(ctx context.Context, re
 
 func (c WorkspaceFileController) CompleteWorkspaceFileUpload(ctx context.Context, req *chorus.CompleteWorkspaceFileUploadRequest) (*chorus.CompleteWorkspaceFileUploadReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	var parts []*filestore.FilePart
 	for _, tgPart := range req.Parts {
 		part, err := converter.WorkspaceFilePartToBusiness(tgPart)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+			return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file part")
 		}
 		parts = append(parts, part)
 	}
 
 	uploadedFile, err := c.workspaceFile.CompleteWorkspaceFileUpload(ctx, req.WorkspaceId, req.Path, req.UploadId, parts)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'CompleteWorkspaceFileUpload': %v", err.Error())
+		return nil, err
 	}
 
 	tgFile, err := converter.WorkspaceFileFromBusiness(uploadedFile)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
 	}
 
 	return &chorus.CompleteWorkspaceFileUploadReply{Result: &chorus.CompleteWorkspaceFileUploadResult{File: tgFile}}, nil
@@ -200,12 +195,12 @@ func (c WorkspaceFileController) CompleteWorkspaceFileUpload(ctx context.Context
 
 func (c WorkspaceFileController) AbortWorkspaceFileUpload(ctx context.Context, req *chorus.AbortWorkspaceFileUploadRequest) (*chorus.AbortWorkspaceFileUploadReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	err := c.workspaceFile.AbortWorkspaceFileUpload(ctx, req.WorkspaceId, req.Path, req.UploadId)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'AbortWorkspaceFileUpload': %v", err.Error())
+		return nil, err
 	}
 
 	return &chorus.AbortWorkspaceFileUploadReply{Result: &chorus.AbortWorkspaceFileUploadResult{}}, nil

--- a/pkg/workspace-file/service/middleware/validation.go
+++ b/pkg/workspace-file/service/middleware/validation.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/client/filestore"
+	cerr "github.com/CHORUS-TRE/chorus-backend/internal/errors"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/workspace-file/service"
 
 	val "github.com/go-playground/validator/v10"
@@ -37,14 +38,14 @@ func (v validation) ListWorkspaceFiles(ctx context.Context, workspaceID uint64, 
 
 func (v validation) CreateWorkspaceFile(ctx context.Context, workspaceID uint64, file *filestore.File) (*filestore.File, error) {
 	if err := v.validate.Struct(file); err != nil {
-		return nil, err
+		return nil, cerr.WrapValidationError(err)
 	}
 	return v.next.CreateWorkspaceFile(ctx, workspaceID, file)
 }
 
 func (v validation) UpdateWorkspaceFile(ctx context.Context, workspaceID uint64, oldPath string, file *filestore.File) (*filestore.File, error) {
 	if err := v.validate.Struct(file); err != nil {
-		return nil, err
+		return nil, cerr.WrapValidationError(err)
 	}
 	return v.next.UpdateWorkspaceFile(ctx, workspaceID, oldPath, file)
 }
@@ -55,14 +56,14 @@ func (v validation) DeleteWorkspaceFile(ctx context.Context, workspaceID uint64,
 
 func (v validation) InitiateWorkspaceFileUpload(ctx context.Context, workspaceID uint64, filePath string, file *filestore.File) (*filestore.FileUploadInfo, error) {
 	if err := v.validate.Struct(file); err != nil {
-		return nil, err
+		return nil, cerr.WrapValidationError(err)
 	}
 	return v.next.InitiateWorkspaceFileUpload(ctx, workspaceID, filePath, file)
 }
 
 func (v validation) UploadWorkspaceFilePart(ctx context.Context, workspaceID uint64, filePath string, uploadID string, part *filestore.FilePart) (*filestore.FilePart, error) {
 	if err := v.validate.Struct(part); err != nil {
-		return nil, err
+		return nil, cerr.WrapValidationError(err)
 	}
 	return v.next.UploadWorkspaceFilePart(ctx, workspaceID, filePath, uploadID, part)
 }
@@ -70,7 +71,7 @@ func (v validation) UploadWorkspaceFilePart(ctx context.Context, workspaceID uin
 func (v validation) CompleteWorkspaceFileUpload(ctx context.Context, workspaceID uint64, filePath string, uploadID string, parts []*filestore.FilePart) (*filestore.File, error) {
 	for _, part := range parts {
 		if err := v.validate.Struct(part); err != nil {
-			return nil, err
+			return nil, cerr.WrapValidationError(err)
 		}
 	}
 	return v.next.CompleteWorkspaceFileUpload(ctx, workspaceID, filePath, uploadID, parts)

--- a/pkg/workspace-file/service/workspace-file-service.go
+++ b/pkg/workspace-file/service/workspace-file-service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/client/filestore"
 	"github.com/CHORUS-TRE/chorus-backend/internal/config"
+	cerr "github.com/CHORUS-TRE/chorus-backend/internal/errors"
 	workspace_model "github.com/CHORUS-TRE/chorus-backend/pkg/workspace/model"
 )
 
@@ -82,7 +83,7 @@ func (s *WorkspaceFileService) selectFileStore(filePath string) (string, error) 
 	}
 
 	if selectedStoreName == "" {
-		return "", fmt.Errorf("no suitable file store found for path %s", filePath)
+		return "", cerr.ErrInvalidRequest.WithMessage(fmt.Sprintf("No suitable file store found for path %s", filePath))
 	}
 
 	return selectedStoreName, nil
@@ -103,15 +104,15 @@ func (s *WorkspaceFileService) listStores() []*filestore.File {
 func (s *WorkspaceFileService) GetWorkspaceFile(ctx context.Context, workspaceID uint64, filePath string) (*filestore.File, error) {
 	storeName, err := s.selectFileStore(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to select file store: %w", err)
+		return nil, err
 	}
 
 	storePath := s.toStorePath(storeName, workspaceID, filePath)
 
-	// For now, only return object Metadata, not the content
+	// Returns only file metadata without content
 	file, err := s.fileStores[storeName].StatFile(ctx, storePath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get workspace file at path %s: %w", filePath, err)
+		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to get workspace file at path %s", filePath))
 	}
 
 	return file, nil
@@ -120,14 +121,14 @@ func (s *WorkspaceFileService) GetWorkspaceFile(ctx context.Context, workspaceID
 func (s *WorkspaceFileService) GetWorkspaceFileWithContent(ctx context.Context, workspaceID uint64, filePath string) (*filestore.File, error) {
 	storeName, err := s.selectFileStore(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to select file store: %w", err)
+		return nil, err
 	}
 
 	storePath := s.toStorePath(storeName, workspaceID, filePath)
 
 	file, err := s.fileStores[storeName].GetFile(ctx, storePath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get workspace file with content at path %s: %w", filePath, err)
+		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to get workspace file with content at path %s", filePath))
 	}
 
 	return file, nil
@@ -140,13 +141,13 @@ func (s *WorkspaceFileService) ListWorkspaceFiles(ctx context.Context, workspace
 
 	storeName, err := s.selectFileStore(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to select file store: %w", err)
+		return nil, err
 	}
 
 	storePath := s.toStorePath(storeName, workspaceID, filePath)
 	storeFiles, err := s.fileStores[storeName].ListFiles(ctx, storePath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to list workspace files at path %s: %w", filePath, err)
+		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to list workspace files at path %s", filePath))
 	}
 
 	var files []*filestore.File
@@ -167,7 +168,7 @@ func (s *WorkspaceFileService) ListWorkspaceFiles(ctx context.Context, workspace
 func (s *WorkspaceFileService) CreateWorkspaceFile(ctx context.Context, workspaceID uint64, file *filestore.File) (*filestore.File, error) {
 	storeName, err := s.selectFileStore(file.Path)
 	if err != nil {
-		return nil, fmt.Errorf("unable to select file store: %w", err)
+		return nil, err
 	}
 
 	storePath := s.toStorePath(storeName, workspaceID, file.Path)
@@ -180,7 +181,7 @@ func (s *WorkspaceFileService) CreateWorkspaceFile(ctx context.Context, workspac
 			IsDirectory: file.IsDirectory,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("unable to create workspace directory at path %s: %w", file.Path, err)
+			return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to create workspace directory at path %s", file.Path))
 		}
 	} else {
 		createdFile, err = s.fileStores[storeName].CreateFile(ctx, &filestore.File{
@@ -191,7 +192,7 @@ func (s *WorkspaceFileService) CreateWorkspaceFile(ctx context.Context, workspac
 			Content:     file.Content,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("unable to create workspace file at path %s: %w", file.Path, err)
+			return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to create workspace file at path %s", file.Path))
 		}
 	}
 
@@ -208,12 +209,12 @@ func (s *WorkspaceFileService) CreateWorkspaceFile(ctx context.Context, workspac
 func (s *WorkspaceFileService) UpdateWorkspaceFile(ctx context.Context, workspaceID uint64, oldPath string, file *filestore.File) (*filestore.File, error) {
 	oldStoreName, err := s.selectFileStore(oldPath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to select file store for old path: %w", err)
+		return nil, err
 	}
 
 	newStoreName, err := s.selectFileStore(file.Path)
 	if err != nil {
-		return nil, fmt.Errorf("unable to select file store for new path: %w", err)
+		return nil, err
 	}
 
 	oldStore := s.fileStores[oldStoreName]
@@ -222,7 +223,7 @@ func (s *WorkspaceFileService) UpdateWorkspaceFile(ctx context.Context, workspac
 	oldStorePath := s.toStorePath(oldStoreName, workspaceID, oldPath)
 	oldFile, err := oldStore.GetFile(ctx, oldStorePath)
 	if err != nil {
-		return nil, fmt.Errorf("workspace file at path %s does not exist: %w", oldPath, err)
+		return nil, cerr.ErrNotFound.Wrap(err, fmt.Sprintf("Workspace file at path %s does not exist", oldPath))
 	}
 
 	if oldStoreName != newStoreName {
@@ -237,13 +238,13 @@ func (s *WorkspaceFileService) UpdateWorkspaceFile(ctx context.Context, workspac
 			Content:     oldFile.Content,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("unable to create new workspace file at path %s: %w", file.Path, err)
+			return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to create new workspace file at path %s", file.Path))
 		}
 
 		err = s.fileStores[oldStoreName].DeleteFile(ctx, oldStorePath)
 		if err != nil {
 			_ = s.fileStores[newStoreName].DeleteFile(ctx, newStorePath)
-			return nil, fmt.Errorf("unable to delete old workspace file at path %s: %w", oldPath, err)
+			return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to delete old workspace file at path %s", oldPath))
 		}
 
 		return &filestore.File{
@@ -260,7 +261,7 @@ func (s *WorkspaceFileService) UpdateWorkspaceFile(ctx context.Context, workspac
 	newStorePath := s.toStorePath(newStoreName, workspaceID, file.Path)
 	updatedFile, err := s.fileStores[oldStoreName].MoveFile(ctx, oldStorePath, newStorePath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to update old workspace file at path %s: %w", oldPath, err)
+		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to move workspace file from path %s", oldPath))
 	}
 
 	return updatedFile, nil
@@ -269,7 +270,7 @@ func (s *WorkspaceFileService) UpdateWorkspaceFile(ctx context.Context, workspac
 func (s *WorkspaceFileService) DeleteWorkspaceFile(ctx context.Context, workspaceID uint64, filePath string) error {
 	storeName, err := s.selectFileStore(filePath)
 	if err != nil {
-		return fmt.Errorf("unable to select file store: %w", err)
+		return err
 	}
 
 	store := s.fileStores[storeName]
@@ -278,12 +279,12 @@ func (s *WorkspaceFileService) DeleteWorkspaceFile(ctx context.Context, workspac
 	if strings.HasSuffix(storePath, "/") {
 		err = store.DeleteDirectory(ctx, storePath)
 		if err != nil {
-			return fmt.Errorf("unable to delete workspace directory at path %s: %w", filePath, err)
+			return cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to delete workspace directory at path %s", filePath))
 		}
 	} else {
 		err = store.DeleteFile(ctx, storePath)
 		if err != nil {
-			return fmt.Errorf("unable to delete workspace file at path %s: %w", filePath, err)
+			return cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to delete workspace file at path %s", filePath))
 		}
 	}
 
@@ -293,7 +294,7 @@ func (s *WorkspaceFileService) DeleteWorkspaceFile(ctx context.Context, workspac
 func (s *WorkspaceFileService) InitiateWorkspaceFileUpload(ctx context.Context, workspaceID uint64, filePath string, file *filestore.File) (*filestore.FileUploadInfo, error) {
 	storeName, err := s.selectFileStore(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to select file store: %w", err)
+		return nil, err
 	}
 
 	store := s.fileStores[storeName]
@@ -307,7 +308,7 @@ func (s *WorkspaceFileService) InitiateWorkspaceFileUpload(ctx context.Context, 
 		Size:        file.Size,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to initiate multipart upload for file at path %s: %w", file.Path, err)
+		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to initiate multipart upload for file at path %s", file.Path))
 	}
 
 	return uploadInfo, nil
@@ -316,7 +317,7 @@ func (s *WorkspaceFileService) InitiateWorkspaceFileUpload(ctx context.Context, 
 func (s *WorkspaceFileService) UploadWorkspaceFilePart(ctx context.Context, workspaceID uint64, filePath string, uploadID string, part *filestore.FilePart) (*filestore.FilePart, error) {
 	storeName, err := s.selectFileStore(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to select file store: %w", err)
+		return nil, err
 	}
 
 	store := s.fileStores[storeName]
@@ -324,7 +325,7 @@ func (s *WorkspaceFileService) UploadWorkspaceFilePart(ctx context.Context, work
 
 	uploadedPart, err := store.UploadPart(ctx, storePath, uploadID, part)
 	if err != nil {
-		return nil, fmt.Errorf("unable to upload part number %d for upload ID %s at path %s: %w", part.PartNumber, uploadID, filePath, err)
+		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to upload part number %d for upload ID %s at path %s", part.PartNumber, uploadID, filePath))
 	}
 
 	return uploadedPart, nil
@@ -333,7 +334,7 @@ func (s *WorkspaceFileService) UploadWorkspaceFilePart(ctx context.Context, work
 func (s *WorkspaceFileService) CompleteWorkspaceFileUpload(ctx context.Context, workspaceID uint64, filePath string, uploadID string, parts []*filestore.FilePart) (*filestore.File, error) {
 	storeName, err := s.selectFileStore(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("unable to select file store: %w", err)
+		return nil, err
 	}
 
 	store := s.fileStores[storeName]
@@ -341,7 +342,7 @@ func (s *WorkspaceFileService) CompleteWorkspaceFileUpload(ctx context.Context, 
 
 	completedFile, err := store.CompleteMultipartUpload(ctx, storePath, uploadID, parts)
 	if err != nil {
-		return nil, fmt.Errorf("unable to complete multipart upload for upload ID %s at path %s: %w", uploadID, filePath, err)
+		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to complete multipart upload for upload ID %s at path %s", uploadID, filePath))
 	}
 
 	return completedFile, nil
@@ -350,7 +351,7 @@ func (s *WorkspaceFileService) CompleteWorkspaceFileUpload(ctx context.Context, 
 func (s *WorkspaceFileService) AbortWorkspaceFileUpload(ctx context.Context, workspaceID uint64, filePath string, uploadID string) error {
 	storeName, err := s.selectFileStore(filePath)
 	if err != nil {
-		return fmt.Errorf("unable to select file store: %w", err)
+		return err
 	}
 
 	store := s.fileStores[storeName]
@@ -358,7 +359,7 @@ func (s *WorkspaceFileService) AbortWorkspaceFileUpload(ctx context.Context, wor
 
 	err = store.AbortMultipartUpload(ctx, storePath, uploadID)
 	if err != nil {
-		return fmt.Errorf("unable to abort multipart upload for upload ID %s at path %s: %w", uploadID, filePath, err)
+		return cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to abort multipart upload for upload ID %s at path %s", uploadID, filePath))
 	}
 
 	return nil


### PR DESCRIPTION
This pull request refactors error handling across the workspace file API and service layers to standardize and improve error reporting. The changes replace raw and gRPC status errors with a centralized custom error package, ensuring more consistent and descriptive error messages throughout the codebase.

**Error Handling Improvements:**

* All controllers in `internal/api/v1/workspace-file-controller.go` now use the custom error package (`cerr`) for error responses, replacing direct usage of gRPC status errors and codes. This includes wrapping conversion errors and invalid requests with more descriptive messages. [[1]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL9-L13) [[2]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL30-R57) [[3]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL72-R136) [[4]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL153-R203)
* The validation middleware in `pkg/workspace-file/service/middleware/validation.go` now wraps validation errors using the custom error package, providing better context for validation failures. [[1]](diffhunk://#diff-5a22d3cdfcba552b3517ad1b2b9809bed1569e1ab63b5f95b48cc60d68cb219aR7) [[2]](diffhunk://#diff-5a22d3cdfcba552b3517ad1b2b9809bed1569e1ab63b5f95b48cc60d68cb219aL40-R48) [[3]](diffhunk://#diff-5a22d3cdfcba552b3517ad1b2b9809bed1569e1ab63b5f95b48cc60d68cb219aL58-R74)

**Service Layer Error Consistency:**

* The service implementation in `pkg/workspace-file/service/workspace-file-service.go` now uses the custom error types for all error cases, replacing `fmt.Errorf` and providing more specific error types (e.g., `ErrInvalidRequest`, `ErrInternal`, `ErrNotFound`). This includes file store selection, file operations, and not-found scenarios. [[1]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744R10) [[2]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L85-R86) [[3]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L106-R115) [[4]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L123-R131) [[5]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L143-R150) [[6]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L170-R171) [[7]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L183-R184) [[8]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L194-R195) [[9]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L211-R217) [[10]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L225-R226) [[11]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L240-R247) [[12]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L263-R264) [[13]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L272-R273)