### PR TITLE
fix(chorus-int): use internal keycloak DNS for server-side token exchange

### DIFF
--- a/configs/chorus-int/values.yaml
+++ b/configs/chorus-int/values.yaml
@@ -134,8 +134,8 @@ config:
             enable_frontend_redirect: true
             chorus_frontend_redirect_url: "https://int.chorus-tre.ch/oauthredirect"
             authorize_url: "https://auth.int.chorus-tre.ch/realms/chorus/protocol/openid-connect/auth"
-            token_url: "https://auth.int.chorus-tre.ch/realms/chorus/protocol/openid-connect/token"
-            user_info_url: "https://auth.int.chorus-tre.ch/realms/chorus/protocol/openid-connect/userinfo"
+            token_url: "http://chorus-int-keycloak.keycloak.svc.cluster.local/realms/chorus/protocol/openid-connect/token"
+            user_info_url: "http://chorus-int-keycloak.keycloak.svc.cluster.local/realms/chorus/protocol/openid-connect/userinfo"
             logout_url: "https://auth.int.chorus-tre.ch/realms/chorus/protocol/openid-connect/logout?client_id=chorus&post_logout_redirect_uri=https://int.chorus-tre.ch"
             user_name_claim: "preferred_username"
             # final_url_format: "https://int.chorus-tre.ch/login?token=%s"


### PR DESCRIPTION
## Keycloak token exchange from backend pod

After migrating `auth.int.chorus-tre.ch` from nginx to Envoy Gateway, the route's SecurityPolicy denies podCIDR (`10.42.0.0/16`). The backend pod is in that CIDR, so its outbound calls to `https://auth.int.chorus-tre.ch/realms/chorus/protocol/openid-connect/token` get rejected by Envoy — failing OIDC login with "Failed to exchange token".

Switching `token_url` and `user_info_url` to cluster-internal DNS (`http://chorus-int-keycloak.keycloak.svc.cluster.local/...`) bypasses Envoy for the server-side calls. Browser-facing URLs (`authorize_url`, `logout_url`) stay on the public hostname. Same keycloak, same realm, same client credentials.

The `keycloakdev` provider is intentionally unchanged (only affects int).