### PR TITLE
fix: bump gatekeeper and fix workspace service instances storage encryption

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ module github.com/CHORUS-TRE/chorus-backend
 go 1.24.3
 
 require (
-	github.com/CHORUS-TRE/chorus-gatekeeper v0.0.0-20260316163116-4511dbc9dfb7
+	github.com/CHORUS-TRE/chorus-gatekeeper v0.0.0-20260505083253-86f6f548c1a4
 	github.com/coocood/freecache v1.2.4
 	github.com/evanphx/json-patch v5.9.11+incompatible
 	github.com/fergusstrange/embedded-postgres v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/CHORUS-TRE/chorus-gatekeeper v0.0.0-20260316163116-4511dbc9dfb7 h1:YXDZnm7n7BHGqeR80psYpOH+sYDYXnojb+QNV/xE9oA=
 github.com/CHORUS-TRE/chorus-gatekeeper v0.0.0-20260316163116-4511dbc9dfb7/go.mod h1:bujVcE7BptlmDYg10vldlH0N62j6OPAW4bILp4qH1Z4=
+github.com/CHORUS-TRE/chorus-gatekeeper v0.0.0-20260505083253-86f6f548c1a4 h1:FY4roViHkFt4D6JKPKPyWJ/7H1QSeeF5BBQJYa0XhuU=
+github.com/CHORUS-TRE/chorus-gatekeeper v0.0.0-20260505083253-86f6f548c1a4/go.mod h1:poKm4o0GPoaIx4/6gpp0JM+mlPwuoyWNGqHCV257EHk=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=

--- a/internal/api/v1/middleware/authorization.go
+++ b/internal/api/v1/middleware/authorization.go
@@ -119,7 +119,7 @@ func (c Authorization) GetContextListForPermission(ctx context.Context, permissi
 func (c Authorization) TriggerRefreshToken(ctx context.Context) error {
 	res, t, err := c.refresher.RefreshToken(ctx)
 	if err != nil {
-		return chorus_errors.ErrUnauthenticated.Wrap(err, err.Error())
+		return chorus_errors.ErrUnauthenticated.Wrap(err, "unable to refresh token")
 	}
 
 	expiresDate := time.Now().Add(t)
@@ -127,7 +127,7 @@ func (c Authorization) TriggerRefreshToken(ctx context.Context) error {
 
 	header := c.getSetCookieHeader(res, expires)
 	if err := grpc.SetHeader(ctx, header); err != nil {
-		return chorus_errors.ErrInternal.Wrap(err, err.Error())
+		return chorus_errors.ErrInternal.Wrap(err, "unable to set grpc set-cookie header")
 	}
 
 	return nil

--- a/internal/api/v1/middleware/authorization.go
+++ b/internal/api/v1/middleware/authorization.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/config"
+	chorus_errors "github.com/CHORUS-TRE/chorus-backend/internal/errors"
 	jwt_model "github.com/CHORUS-TRE/chorus-backend/internal/jwt/model"
 	"github.com/CHORUS-TRE/chorus-backend/internal/logger"
 	authorization "github.com/CHORUS-TRE/chorus-backend/pkg/authorization/model"
@@ -13,9 +14,7 @@ import (
 
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
-	"google.golang.org/grpc/status"
 )
 
 type Refresher interface {
@@ -45,13 +44,13 @@ func (c Authorization) getRolesAndClaims(ctx context.Context) ([]authorization.R
 	claims, ok := ctx.Value(jwt_model.JWTClaimsContextKey).(*jwt_model.JWTClaims)
 	if !ok {
 		c.logger.Warn(ctx, "malformed JWT token", zap.Any("content", ctx.Value(jwt_model.JWTClaimsContextKey)))
-		return nil, nil, status.Error(codes.Unauthenticated, "malformed jwt-token")
+		return nil, nil, chorus_errors.ErrUnauthenticated.WithMessage("malformed jwt-token")
 	}
 
 	aRoles, err := claimRolesToAuthRoles(claims)
 	if err != nil {
 		c.logger.Error(ctx, "failed to convert claim roles to auth roles", zap.Error(err))
-		return nil, nil, status.Error(codes.Internal, "failed to convert claim roles to auth roles")
+		return nil, nil, chorus_errors.ErrInternal.Wrap(err, "failed to convert claim roles to auth roles")
 	}
 
 	return aRoles, claims, nil
@@ -61,7 +60,7 @@ func (c Authorization) getUserID(ctx context.Context) (uint64, error) {
 	claims, ok := ctx.Value(jwt_model.JWTClaimsContextKey).(*jwt_model.JWTClaims)
 	if !ok {
 		c.logger.Warn(ctx, "malformed JWT token")
-		return 0, status.Error(codes.Unauthenticated, "malformed jwt-token")
+		return 0, chorus_errors.ErrUnauthenticated.WithMessage("malformed jwt-token")
 	}
 
 	return claims.ID, nil
@@ -73,13 +72,13 @@ func (c Authorization) IsAuthorized(ctx context.Context, permissionName authoriz
 	aRoles, claims, err := c.getRolesAndClaims(ctx)
 	if err != nil {
 		c.logger.Error(ctx, "failed to get roles and claims", zap.Error(err))
-		return status.Error(codes.Internal, "failed to get roles and claims")
+		return err
 	}
 
 	isAuthorized, err := c.authorizer.IsUserAllowed(aRoles, permission)
 	if err != nil {
 		c.logger.Error(ctx, "authorization error", zap.Error(err))
-		return status.Error(codes.Internal, "authorization error")
+		return chorus_errors.ErrInternal.Wrap(err, "authorization error")
 	}
 
 	if !isAuthorized {
@@ -105,13 +104,13 @@ func (c Authorization) GetContextListForPermission(ctx context.Context, permissi
 	aRoles, _, err := c.getRolesAndClaims(ctx)
 	if err != nil {
 		c.logger.Error(ctx, "failed to get roles and claims", zap.Error(err))
-		return nil, status.Error(codes.Internal, "failed to get roles and claims")
+		return nil, err
 	}
 
 	contextList, err := c.authorizer.GetContextListForPermission(aRoles, permissionName)
 	if err != nil {
 		c.logger.Error(ctx, "authorization error", zap.Error(err))
-		return nil, status.Error(codes.Internal, "authorization error")
+		return nil, chorus_errors.ErrInternal.Wrap(err, "authorization error")
 	}
 
 	return contextList, nil
@@ -120,7 +119,7 @@ func (c Authorization) GetContextListForPermission(ctx context.Context, permissi
 func (c Authorization) TriggerRefreshToken(ctx context.Context) error {
 	res, t, err := c.refresher.RefreshToken(ctx)
 	if err != nil {
-		return status.Errorf(codes.Unauthenticated, "%v", err)
+		return chorus_errors.ErrUnauthenticated.Wrap(err, err.Error())
 	}
 
 	expiresDate := time.Now().Add(t)
@@ -128,7 +127,7 @@ func (c Authorization) TriggerRefreshToken(ctx context.Context) error {
 
 	header := c.getSetCookieHeader(res, expires)
 	if err := grpc.SetHeader(ctx, header); err != nil {
-		return status.Errorf(codes.Internal, "%v", err)
+		return chorus_errors.ErrInternal.Wrap(err, err.Error())
 	}
 
 	return nil
@@ -151,7 +150,7 @@ func (c Authorization) permissionDenied(ctx context.Context, claims *jwt_model.J
 		zap.String("required_permission", string(p.Name)),
 		zap.Strings("user_permissions", authorization.UniquePermissionNames(permissions)),
 		zap.Strings("user_roles", authorization.UniqueRoleNames(claims.Roles)))
-	return status.Errorf(codes.PermissionDenied, "required permission: %v", p)
+	return chorus_errors.ErrPermissionDenied.WithMessage(fmt.Sprintf("required permission: %v", p))
 }
 
 func claimRolesToAuthRoles(claims *jwt_model.JWTClaims) ([]authorization.Role, error) {

--- a/internal/client/k8s/k8s.go
+++ b/internal/client/k8s/k8s.go
@@ -114,20 +114,20 @@ func (c *client) syncResource(spec interface{}, kind, name, namespace, specField
 
 	if len(patch) > 0 && string(patch) != "{}" {
 		updatedSpec := map[string]interface{}{
-			specFieldName: json.RawMessage(desiredSpecBytes),
+			specFieldName: json.RawMessage(patch),
 		}
 
-		patch, err := json.Marshal(updatedSpec)
+		patchBytes, err := json.Marshal(updatedSpec)
 		if err != nil {
 			return fmt.Errorf("error marshalling patch: %w", err)
 		}
 
 		logger.TechLog.Info(context.Background(), "Resource not in the correct state, applying patch",
 			zap.String("namespace", namespace), zap.String("kind", kind), zap.String("name", name),
-			zap.String("patch", string(patch)),
+			zap.String("patch", string(patchBytes)),
 		)
 
-		_, err = c.dynamicClient.Resource(gvr).Namespace(namespace).Patch(context.Background(), name, types.MergePatchType, patch, v1.PatchOptions{})
+		_, err = c.dynamicClient.Resource(gvr).Namespace(namespace).Patch(context.Background(), name, types.MergePatchType, patchBytes, v1.PatchOptions{})
 		if err != nil {
 			return fmt.Errorf("error applying patch: %w", err)
 		}

--- a/pkg/workspace/store/postgres/workspace-storage.go
+++ b/pkg/workspace/store/postgres/workspace-storage.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -490,10 +489,17 @@ func (s *WorkspaceStorage) encryptSensitiveFields(svc *model.WorkspaceServiceIns
 	}
 	valuesStr, _ := valuesVal.(string)
 
-	encValues, err = crypto.EncryptField(valuesStr, s.daemonKey)
+	enc, err := crypto.EncryptField(valuesStr, s.daemonKey)
 	if err != nil {
 		return "", "", nil, fmt.Errorf("unable to encrypt values: %w", err)
 	}
+	// Wrap in a JSON object so the JSONB column receives valid JSON.
+	// The "_enc" sentinel lets decryptServiceInstance detect the encrypted case after scanning.
+	b, err := json.Marshal(map[string]string{"_enc": enc})
+	if err != nil {
+		return "", "", nil, fmt.Errorf("unable to marshal encrypted values: %w", err)
+	}
+	encValues = string(b)
 
 	encCredName, err = crypto.EncryptField(svc.CredentialsSecretName, s.daemonKey)
 	if err != nil {
@@ -515,36 +521,20 @@ func (s *WorkspaceStorage) encryptSensitiveFields(svc *model.WorkspaceServiceIns
 }
 
 func (s *WorkspaceStorage) decryptServiceInstance(svc *model.WorkspaceServiceInstance) error {
-	// Decrypt valuesoverride (stored as encrypted JSON string)
-	var rawValues string
-	if svc.Values != nil {
-		b, err := json.Marshal(svc.Values)
+	// Values are stored encrypted as {"_enc": "<ciphertext>"} in the JSONB column.
+	if enc, ok := svc.Values["_enc"]; ok {
+		encStr, _ := enc.(string)
+		decValues, err := crypto.DecryptField(encStr, s.daemonKey)
 		if err != nil {
-			return fmt.Errorf("unable to marshal values for decryption: %w", err)
+			return fmt.Errorf("unable to decrypt values: %w", err)
 		}
-		rawValues = string(b)
-	}
-	// The DB stores the encrypted form as a plain string in a JSONB column.
-	// After scanning, the JSONMap contains a single string. We need to check
-	// if the raw value is an encrypted string (starts with a quote in the JSON).
-	// If the daemon key is nil, we skip decryption (unencrypted data).
-	if s.daemonKey != nil && rawValues != "" && rawValues != "{}" {
-		// Try to extract the raw string from the JSONB (it may be stored as a quoted encrypted string)
-		rawValues = strings.TrimSpace(rawValues)
-		if len(rawValues) > 0 && rawValues[0] != '{' {
-			// It's an encrypted string, not a JSON object
-			decValues, err := crypto.DecryptField(strings.Trim(rawValues, "\""), s.daemonKey)
-			if err != nil {
-				return fmt.Errorf("unable to decrypt values: %w", err)
+		m := make(model.JSONMap[any])
+		if decValues != "" {
+			if err := json.Unmarshal([]byte(decValues), &m); err != nil {
+				return fmt.Errorf("unable to unmarshal decrypted values: %w", err)
 			}
-			m := make(model.JSONMap[any])
-			if decValues != "" {
-				if err := json.Unmarshal([]byte(decValues), &m); err != nil {
-					return fmt.Errorf("unable to unmarshal decrypted values: %w", err)
-				}
-			}
-			svc.Values = m
 		}
+		svc.Values = m
 	}
 
 	if s.daemonKey != nil && svc.CredentialsSecretName != "" {

--- a/pkg/workspace/store/postgres/workspace-storage.go
+++ b/pkg/workspace/store/postgres/workspace-storage.go
@@ -522,19 +522,21 @@ func (s *WorkspaceStorage) encryptSensitiveFields(svc *model.WorkspaceServiceIns
 
 func (s *WorkspaceStorage) decryptServiceInstance(svc *model.WorkspaceServiceInstance) error {
 	// Values are stored encrypted as {"_enc": "<ciphertext>"} in the JSONB column.
-	if enc, ok := svc.Values["_enc"]; ok {
-		encStr, _ := enc.(string)
-		decValues, err := crypto.DecryptField(encStr, s.daemonKey)
-		if err != nil {
-			return fmt.Errorf("unable to decrypt values: %w", err)
-		}
-		m := make(model.JSONMap[any])
-		if decValues != "" {
-			if err := json.Unmarshal([]byte(decValues), &m); err != nil {
-				return fmt.Errorf("unable to unmarshal decrypted values: %w", err)
+	if s.daemonKey != nil {
+		if enc, ok := svc.Values["_enc"]; ok {
+			encStr, _ := enc.(string)
+			decValues, err := crypto.DecryptField(encStr, s.daemonKey)
+			if err != nil {
+				return fmt.Errorf("unable to decrypt values: %w", err)
 			}
+			m := make(model.JSONMap[any])
+			if decValues != "" {
+				if err := json.Unmarshal([]byte(decValues), &m); err != nil {
+					return fmt.Errorf("unable to unmarshal decrypted values: %w", err)
+				}
+			}
+			svc.Values = m
 		}
-		svc.Values = m
 	}
 
 	if s.daemonKey != nil && svc.CredentialsSecretName != "" {

--- a/pkg/workspace/store/postgres/workspace-storage.go
+++ b/pkg/workspace/store/postgres/workspace-storage.go
@@ -524,7 +524,10 @@ func (s *WorkspaceStorage) decryptServiceInstance(svc *model.WorkspaceServiceIns
 	// Values are stored encrypted as {"_enc": "<ciphertext>"} in the JSONB column.
 	if s.daemonKey != nil {
 		if enc, ok := svc.Values["_enc"]; ok {
-			encStr, _ := enc.(string)
+			encStr, ok := enc.(string)
+			if !ok {
+				return fmt.Errorf("unexpected type for _enc field: %T", enc)
+			}
 			decValues, err := crypto.DecryptField(encStr, s.daemonKey)
 			if err != nil {
 				return fmt.Errorf("unable to decrypt values: %w", err)


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to error handling, Kubernetes resource patching, and encryption of sensitive fields in the workspace storage. The main focus is on unifying and improving error handling by replacing gRPC status errors with custom error types, ensuring valid JSON storage for encrypted fields, and correcting the Kubernetes patch logic.

**Error handling improvements:**

* Replaced usage of gRPC `status.Error` and `status.Errorf` with custom error types from `chorus_errors` throughout the `internal/api/v1/middleware/authorization.go` middleware for more consistent and informative error handling. [[1]](diffhunk://#diff-7b59f67295c8cea5acf8a05b1fdb75be8c8153b8c9d03474c807d35915172e68R9-L18) [[2]](diffhunk://#diff-7b59f67295c8cea5acf8a05b1fdb75be8c8153b8c9d03474c807d35915172e68L48-R53) [[3]](diffhunk://#diff-7b59f67295c8cea5acf8a05b1fdb75be8c8153b8c9d03474c807d35915172e68L64-R63) [[4]](diffhunk://#diff-7b59f67295c8cea5acf8a05b1fdb75be8c8153b8c9d03474c807d35915172e68L76-R81) [[5]](diffhunk://#diff-7b59f67295c8cea5acf8a05b1fdb75be8c8153b8c9d03474c807d35915172e68L108-R113) [[6]](diffhunk://#diff-7b59f67295c8cea5acf8a05b1fdb75be8c8153b8c9d03474c807d35915172e68L123-R130) [[7]](diffhunk://#diff-7b59f67295c8cea5acf8a05b1fdb75be8c8153b8c9d03474c807d35915172e68L154-R153)

**Kubernetes resource patching:**

* Fixed a bug in `internal/client/k8s/k8s.go` where the patch applied to Kubernetes resources was not properly marshaled, which could have resulted in incorrect patching behavior. Now, the correct patch bytes are generated and logged.

**Encryption and storage of sensitive fields:**

* Updated the encryption logic in `pkg/workspace/store/postgres/workspace-storage.go` to wrap encrypted values in a JSON object with an `_enc` sentinel, ensuring valid JSONB storage and easier detection of encrypted data.
* Simplified and corrected the decryption logic to properly detect and decrypt values stored in the new JSON object format, removing unnecessary string manipulation and reliance on marshaling.

**Dependency update:**

* Updated the `github.com/CHORUS-TRE/chorus-gatekeeper` dependency to a newer version in `go.mod`.