### PR TITLE
fix: add name and shortname in workbench update query

### DIFF
--- a/pkg/workbench/store/postgres/workbench-storage.go
+++ b/pkg/workbench/store/postgres/workbench-storage.go
@@ -224,14 +224,14 @@ func (s *WorkbenchStorage) CreateWorkbench(ctx context.Context, tenantID uint64,
 func (s *WorkbenchStorage) UpdateWorkbench(ctx context.Context, tenantID uint64, workbench *model.Workbench) (*model.Workbench, error) {
 	const workbenchUpdateQuery = `
 		UPDATE workbenches
-		SET status = $3, serverpodstatus = $4, serverpodmessage = $5, k8sstatus = $6, description = $7, updatedat = NOW()
+		SET name = $3, shortname = $4, description = $5, status = $6, serverpodstatus = $7, serverpodmessage = $8, k8sstatus = $9, updatedat = NOW()
 		WHERE tenantid = $1 AND id = $2
 		RETURNING id, tenantid, userid, workspaceid, name, shortname, description, status, serverpodstatus, serverpodmessage, k8sstatus, initialresolutionwidth, initialresolutionheight, createdat, updatedat;
 	`
 
 	// Update workbench
 	var updatedWorkbench model.Workbench
-	err := s.db.GetContext(ctx, &updatedWorkbench, workbenchUpdateQuery, tenantID, workbench.ID, workbench.Status, workbench.ServerPodStatus, workbench.ServerPodMessage, workbench.K8sStatus, workbench.Description)
+	err := s.db.GetContext(ctx, &updatedWorkbench, workbenchUpdateQuery, tenantID, workbench.ID, workbench.Name, workbench.ShortName, workbench.Description, workbench.Status, workbench.ServerPodStatus, workbench.ServerPodMessage, workbench.K8sStatus)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request updates the `UpdateWorkbench` method in `workbench-storage.go` to allow editing additional fields when updating a workbench. Previously, only status and a few other fields could be updated; now, `name` and `shortname` can also be modified.

**Workbench update improvements:**

* The SQL update query in `UpdateWorkbench` now sets `name` and `shortname` fields, in addition to the existing fields.
* The method parameters passed to the query were updated to include `workbench.Name` and `workbench.ShortName` in the correct order.