### PR TITLE
feat: improve workspace file service error handling and messages

### DIFF
--- a/internal/api/v1/workspace-file-controller.go
+++ b/internal/api/v1/workspace-file-controller.go
@@ -52,7 +52,7 @@ func (c WorkspaceFileController) GetWorkspaceFile(ctx context.Context, req *chor
 
 	tgFile, err := converter.WorkspaceFileFromBusiness(file)
 	if err != nil {
-		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
+		return nil, err
 	}
 
 	return &chorus.GetWorkspaceFileReply{Result: &chorus.GetWorkspaceFileResult{File: tgFile}}, nil
@@ -72,7 +72,7 @@ func (c WorkspaceFileController) ListWorkspaceFiles(ctx context.Context, req *ch
 	for _, file := range files {
 		tgFile, err := converter.WorkspaceFileFromBusiness(file)
 		if err != nil {
-			return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
+			return nil, err
 		}
 		tgFiles = append(tgFiles, tgFile)
 	}
@@ -87,7 +87,7 @@ func (c WorkspaceFileController) CreateWorkspaceFile(ctx context.Context, req *c
 
 	file, err := converter.WorkspaceFileToBusiness(req.File)
 	if err != nil {
-		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
+		return nil, err
 	}
 
 	newFile, err := c.workspaceFile.CreateWorkspaceFile(ctx, req.WorkspaceId, file)
@@ -97,7 +97,7 @@ func (c WorkspaceFileController) CreateWorkspaceFile(ctx context.Context, req *c
 
 	tgFile, err := converter.WorkspaceFileFromBusiness(newFile)
 	if err != nil {
-		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
+		return nil, err
 	}
 
 	return &chorus.CreateWorkspaceFileReply{Result: &chorus.CreateWorkspaceFileResult{File: tgFile}}, nil
@@ -110,7 +110,7 @@ func (c WorkspaceFileController) UpdateWorkspaceFile(ctx context.Context, req *c
 
 	file, err := converter.WorkspaceFileToBusiness(req.File)
 	if err != nil {
-		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
+		return nil, err
 	}
 
 	updatedFile, err := c.workspaceFile.UpdateWorkspaceFile(ctx, req.WorkspaceId, req.OldPath, file, req.IsCopy)
@@ -120,7 +120,7 @@ func (c WorkspaceFileController) UpdateWorkspaceFile(ctx context.Context, req *c
 
 	tgFile, err := converter.WorkspaceFileFromBusiness(updatedFile)
 	if err != nil {
-		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
+		return nil, err
 	}
 
 	return &chorus.UpdateWorkspaceFileReply{Result: &chorus.UpdateWorkspaceFileResult{File: tgFile}}, nil
@@ -146,7 +146,7 @@ func (c WorkspaceFileController) InitiateWorkspaceFileUpload(ctx context.Context
 
 	file, err := converter.WorkspaceFileToBusiness(req.File)
 	if err != nil {
-		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
+		return nil, err
 	}
 
 	uploadInfo, err := c.workspaceFile.InitiateWorkspaceFileUpload(ctx, req.WorkspaceId, req.Path, file)
@@ -168,7 +168,7 @@ func (c WorkspaceFileController) UploadWorkspaceFilePart(ctx context.Context, re
 
 	filePart, err := converter.WorkspaceFilePartToBusiness(req.Part)
 	if err != nil {
-		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file part")
+		return nil, err
 	}
 
 	uploadedPart, err := c.workspaceFile.UploadWorkspaceFilePart(ctx, req.WorkspaceId, req.Path, req.UploadId, filePart)
@@ -178,7 +178,7 @@ func (c WorkspaceFileController) UploadWorkspaceFilePart(ctx context.Context, re
 
 	part, err := converter.WorkspaceFilePartFromBusiness(uploadedPart)
 	if err != nil {
-		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file part")
+		return nil, err
 	}
 
 	return &chorus.UploadWorkspaceFilePartReply{Result: &chorus.UploadWorkspaceFilePartResult{Part: part}}, nil
@@ -193,7 +193,7 @@ func (c WorkspaceFileController) CompleteWorkspaceFileUpload(ctx context.Context
 	for _, tgPart := range req.Parts {
 		part, err := converter.WorkspaceFilePartToBusiness(tgPart)
 		if err != nil {
-			return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file part")
+			return nil, err
 		}
 		parts = append(parts, part)
 	}
@@ -205,7 +205,7 @@ func (c WorkspaceFileController) CompleteWorkspaceFileUpload(ctx context.Context
 
 	tgFile, err := converter.WorkspaceFileFromBusiness(uploadedFile)
 	if err != nil {
-		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert workspace file")
+		return nil, err
 	}
 
 	return &chorus.CompleteWorkspaceFileUploadReply{Result: &chorus.CompleteWorkspaceFileUploadResult{File: tgFile}}, nil

--- a/pkg/workspace-file/service/workspace-file-service.go
+++ b/pkg/workspace-file/service/workspace-file-service.go
@@ -223,6 +223,10 @@ func (s *WorkspaceFileService) CreateWorkspaceFile(ctx context.Context, workspac
 	storePath := s.toStorePath(storeName, workspaceID, file.Path)
 	store := s.stores[storeName].store
 
+	if _, statErr := store.StatFile(ctx, storePath); statErr == nil {
+		return nil, cerr.ErrAlreadyExists.WithMessage(fmt.Sprintf("Workspace file already exists at path %s", file.Path))
+	}
+
 	var createdFile *filestore.File
 	if file.IsDirectory {
 		createdFile, err = store.CreateDirectory(ctx, &filestore.File{
@@ -379,6 +383,11 @@ func (s *WorkspaceFileService) DeleteWorkspaceFile(ctx context.Context, workspac
 
 	store := s.stores[storeName].store
 	storePath := s.toStorePath(storeName, workspaceID, filePath)
+
+	if _, statErr := store.StatFile(ctx, storePath); statErr != nil {
+		return cerr.ErrNotFound.Wrap(statErr, fmt.Sprintf("Workspace file at path %s does not exist", filePath))
+	}
+
 	if strings.HasSuffix(storePath, "/") {
 		err = store.DeleteDirectory(ctx, storePath)
 		if err != nil {
@@ -402,6 +411,10 @@ func (s *WorkspaceFileService) InitiateWorkspaceFileUpload(ctx context.Context, 
 
 	store := s.stores[storeName].store
 	storePath := s.toStorePath(storeName, workspaceID, file.Path)
+
+	if _, statErr := store.StatFile(ctx, storePath); statErr == nil {
+		return nil, cerr.ErrAlreadyExists.WithMessage(fmt.Sprintf("Workspace file already exists at path %s", file.Path))
+	}
 
 	uploadInfo, err := store.InitiateMultipartUpload(ctx, &filestore.File{
 		Path:        storePath,

--- a/pkg/workspace-file/service/workspace-file-service.go
+++ b/pkg/workspace-file/service/workspace-file-service.go
@@ -165,7 +165,7 @@ func (s *WorkspaceFileService) GetWorkspaceFile(ctx context.Context, workspaceID
 	// Returns only file metadata without content
 	file, err := s.stores[storeName].store.StatFile(ctx, storePath)
 	if err != nil {
-		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to get workspace file at path %s", filePath))
+		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to get file at path %s", filePath))
 	}
 
 	return file, nil
@@ -181,7 +181,7 @@ func (s *WorkspaceFileService) GetWorkspaceFileWithContent(ctx context.Context, 
 
 	file, err := s.stores[storeName].store.GetFile(ctx, storePath)
 	if err != nil {
-		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to get workspace file with content at path %s", filePath))
+		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to get file with content at path %s", filePath))
 	}
 
 	return file, nil
@@ -196,7 +196,7 @@ func (s *WorkspaceFileService) ListWorkspaceFiles(ctx context.Context, workspace
 	storePath := s.toStorePath(storeName, workspaceID, filePath)
 	storeFiles, err := s.stores[storeName].store.ListFiles(ctx, storePath)
 	if err != nil {
-		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to list workspace files at path %s", filePath))
+		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to list files at path %s", filePath))
 	}
 
 	var files []*filestore.File
@@ -224,7 +224,7 @@ func (s *WorkspaceFileService) CreateWorkspaceFile(ctx context.Context, workspac
 	store := s.stores[storeName].store
 
 	if _, statErr := store.StatFile(ctx, storePath); statErr == nil {
-		return nil, cerr.ErrAlreadyExists.WithMessage(fmt.Sprintf("Workspace file already exists at path %s", file.Path))
+		return nil, cerr.ErrAlreadyExists.WithMessage(fmt.Sprintf("File already exists at path %s", file.Path))
 	}
 
 	var createdFile *filestore.File
@@ -235,7 +235,7 @@ func (s *WorkspaceFileService) CreateWorkspaceFile(ctx context.Context, workspac
 			IsDirectory: file.IsDirectory,
 		})
 		if err != nil {
-			return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to create workspace directory at path %s", file.Path))
+			return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to create directory at path %s", file.Path))
 		}
 	} else {
 		createdFile, err = store.CreateFile(ctx, &filestore.File{
@@ -246,7 +246,7 @@ func (s *WorkspaceFileService) CreateWorkspaceFile(ctx context.Context, workspac
 			Content:     file.Content,
 		})
 		if err != nil {
-			return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to create workspace file at path %s", file.Path))
+			return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to create file at path %s", file.Path))
 		}
 	}
 
@@ -278,23 +278,23 @@ func (s *WorkspaceFileService) UpdateWorkspaceFile(ctx context.Context, workspac
 	destinationStore := s.stores[destinationStoreName].store
 
 	if strings.HasSuffix(sourcePath, "/") {
-		return nil, cerr.ErrInvalidRequest.WithMessage(fmt.Sprintf("Workspace file at path %s is a directory", sourcePath))
+		return nil, cerr.ErrInvalidRequest.WithMessage(fmt.Sprintf("File at path %s is a directory", sourcePath))
 	}
 
 	if !isCopy && sourceStoreName == destinationStoreName {
 		// Same-store move
 		_, err = sourceStore.StatFile(ctx, sourceStorePath)
 		if err != nil {
-			return nil, cerr.ErrNotFound.Wrap(err, fmt.Sprintf("Workspace file at path %s does not exist", sourcePath))
+			return nil, cerr.ErrNotFound.Wrap(err, fmt.Sprintf("File at path %s does not exist", sourcePath))
 		}
 
 		if _, statErr := sourceStore.StatFile(ctx, destinationStorePath); statErr == nil {
-			return nil, cerr.ErrAlreadyExists.WithMessage(fmt.Sprintf("Workspace file already exists at path %s", file.Path))
+			return nil, cerr.ErrAlreadyExists.WithMessage(fmt.Sprintf("File already exists at path %s", file.Path))
 		}
 
 		updatedFile, err := sourceStore.MoveFile(ctx, sourceStorePath, destinationStorePath)
 		if err != nil {
-			return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to move workspace file from path %s", sourcePath))
+			return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to move file from path %s", sourcePath))
 		}
 
 		return &filestore.File{
@@ -310,12 +310,12 @@ func (s *WorkspaceFileService) UpdateWorkspaceFile(ctx context.Context, workspac
 	// Copy (same-store or cross-store) and cross-store move
 	sourceFile, err := sourceStore.StatFile(ctx, sourceStorePath)
 	if err != nil {
-		return nil, cerr.ErrNotFound.Wrap(err, fmt.Sprintf("Workspace file at path %s does not exist", sourcePath))
+		return nil, cerr.ErrNotFound.Wrap(err, fmt.Sprintf("File at path %s does not exist", sourcePath))
 	}
 
 	// Check if destination file already exists
 	if _, statErr := destinationStore.StatFile(ctx, destinationStorePath); statErr == nil {
-		return nil, cerr.ErrAlreadyExists.WithMessage(fmt.Sprintf("Workspace file already exists at path %s", file.Path))
+		return nil, cerr.ErrAlreadyExists.WithMessage(fmt.Sprintf("File already exists at path %s", file.Path))
 	}
 
 	uploadInfo, err := destinationStore.InitiateMultipartUpload(ctx, &filestore.File{
@@ -326,7 +326,7 @@ func (s *WorkspaceFileService) UpdateWorkspaceFile(ctx context.Context, workspac
 		Size:        sourceFile.Size,
 	})
 	if err != nil {
-		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to initiate multipart upload for workspace file at path %s", file.Path))
+		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to initiate multipart upload for file at path %s", file.Path))
 	}
 
 	// Ensure multipart upload is aborted if anything goes wrong during the copy process
@@ -342,26 +342,26 @@ func (s *WorkspaceFileService) UpdateWorkspaceFile(ctx context.Context, workspac
 	// Stream file from source to destination in parts
 	reader, _, err := sourceStore.GetFileStream(ctx, sourceStorePath)
 	if err != nil {
-		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to open stream for workspace file at path %s", sourceStorePath))
+		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to open stream for file at path %s", sourceStorePath))
 	}
 	defer reader.Close()
 
 	parts, err := uploadFromReader(ctx, destinationStore, destinationStorePath, uploadInfo.UploadID, uploadInfo.PartSize, reader)
 	if err != nil {
-		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to upload workspace file at path %s", file.Path))
+		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to upload file at path %s", file.Path))
 	}
 
 	// Complete the multipart upload to finalize the copy
 	createdFile, err := destinationStore.CompleteMultipartUpload(ctx, destinationStorePath, uploadInfo.UploadID, parts)
 	if err != nil {
-		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to complete multipart upload for workspace file at path %s", file.Path))
+		return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to complete multipart upload for file at path %s", file.Path))
 	}
 	completed = true
 
 	// Delete source file if this is a move operation (not copy)
 	if !isCopy {
 		if err := sourceStore.DeleteFile(ctx, sourceStorePath); err != nil {
-			return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to delete source workspace file at path %s after move (file was copied to destination but source was not removed)", sourceStorePath))
+			return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to delete source file at path %s after move (file was copied to destination but source was not removed)", sourceStorePath))
 		}
 	}
 
@@ -385,18 +385,18 @@ func (s *WorkspaceFileService) DeleteWorkspaceFile(ctx context.Context, workspac
 	storePath := s.toStorePath(storeName, workspaceID, filePath)
 
 	if _, statErr := store.StatFile(ctx, storePath); statErr != nil {
-		return cerr.ErrNotFound.Wrap(statErr, fmt.Sprintf("Workspace file at path %s does not exist", filePath))
+		return cerr.ErrNotFound.Wrap(statErr, fmt.Sprintf("File at path %s does not exist", filePath))
 	}
 
 	if strings.HasSuffix(storePath, "/") {
 		err = store.DeleteDirectory(ctx, storePath)
 		if err != nil {
-			return cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to delete workspace directory at path %s", filePath))
+			return cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to delete directory at path %s", filePath))
 		}
 	} else {
 		err = store.DeleteFile(ctx, storePath)
 		if err != nil {
-			return cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to delete workspace file at path %s", filePath))
+			return cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to delete file at path %s", filePath))
 		}
 	}
 
@@ -413,7 +413,7 @@ func (s *WorkspaceFileService) InitiateWorkspaceFileUpload(ctx context.Context, 
 	storePath := s.toStorePath(storeName, workspaceID, file.Path)
 
 	if _, statErr := store.StatFile(ctx, storePath); statErr == nil {
-		return nil, cerr.ErrAlreadyExists.WithMessage(fmt.Sprintf("Workspace file already exists at path %s", file.Path))
+		return nil, cerr.ErrAlreadyExists.WithMessage(fmt.Sprintf("File already exists at path %s", file.Path))
 	}
 
 	uploadInfo, err := store.InitiateMultipartUpload(ctx, &filestore.File{


### PR DESCRIPTION
This pull request focuses on improving error handling and messaging for workspace file operations, as well as adding additional checks for file existence in the workspace file service. The changes make error messages more consistent and user-friendly, and enhance validation to prevent duplicate file creation and handle missing files more gracefully.

**Error handling and messaging improvements:**

* Updated error messages throughout `pkg/workspace-file/service/workspace-file-service.go` to consistently use "file at path" instead of "workspace file at path", making them clearer and more uniform. [[1]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L168-R168) [[2]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L184-R184) [[3]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L199-R199) [[4]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L234-R238) [[5]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L245-R249) [[6]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L277-R297) [[7]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L309-R318) [[8]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L325-R329) [[9]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L341-R364) [[10]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744R386-R399)
* In `internal/api/v1/workspace-file-controller.go`, removed wrapping of conversion errors with `cerr.ErrConversion` in favor of returning the raw error, making error propagation simpler and more direct. [[1]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL55-R55) [[2]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL75-R75) [[3]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL90-R90) [[4]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL100-R100) [[5]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL113-R113) [[6]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL123-R123) [[7]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL149-R149) [[8]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL171-R171) [[9]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL181-R181) [[10]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL196-R196) [[11]](diffhunk://#diff-47a50a5fcfc26b5545c33f1ce1c3f9cfd1308c4091d06a569f700d33a8a749caL208-R208)

**Validation and existence checks:**

* Added pre-existence checks in `CreateWorkspaceFile`, `InitiateWorkspaceFileUpload`, and `DeleteWorkspaceFile` to prevent duplicate file creation and provide accurate errors when files do not exist. [[1]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744R226-R229) [[2]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744R415-R418) [[3]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744R386-R399)
* Improved error handling for file operations such as move, copy, and delete to return more precise error codes (`ErrAlreadyExists`, `ErrNotFound`) when appropriate. [[1]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L277-R297) [[2]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L309-R318) [[3]](diffhunk://#diff-f19e0884afbb3eea91f163a15bfd5a0c55d1d3f67ba58a536dac41ca86ca4744L341-R364)

These changes help make the workspace file API more robust, predictable, and user-friendly by improving error clarity and enforcing correct file operation semantics.