### PR TITLE
fix: improve workbench status updates to fetch existing workbench info in store

### DIFF
--- a/pkg/workbench/service/workbench-service.go
+++ b/pkg/workbench/service/workbench-service.go
@@ -209,17 +209,17 @@ func (s *WorkbenchService) SetClientWatchers() {
 			return fmt.Errorf("unable to get namespace ID from cluster name %s: %w", k8sWorkbench.Namespace, err)
 		}
 
-		// Build workbench model from received K8s workbench
-		workbench := &model.Workbench{
-			ID:                      workbenchID,
-			TenantID:                k8sWorkbench.TenantID,
-			WorkspaceID:             workspaceID,
-			InitialResolutionWidth:  k8sWorkbench.InitialResolutionWidth,
-			InitialResolutionHeight: k8sWorkbench.InitialResolutionHeight,
-			ServerPodStatus:         model.WorkbenchServerPodStatus(k8sWorkbench.ServerPodStatus),
-			ServerPodMessage:        model.WorbenchServerPodMessage(k8sWorkbench.ServerPodMessage),
-			K8sStatus:               model.K8sWorkbenchStatus(k8sWorkbench.Status),
+		// Fetch existing workbench
+		workbench, err := s.store.GetWorkbench(ctx, k8sWorkbench.TenantID, workbenchID)
+		if err != nil {
+			logger.TechLog.Error(ctx, "unable to get workbench for k8s status update", zap.String("namespace", k8sWorkbench.Namespace), zap.String("workbenchName", k8sWorkbench.Name), zap.Error(err))
+			return fmt.Errorf("unable to get workbench %d: %w", workbenchID, err)
 		}
+
+		// Overwrite k8s-derived statuses
+		workbench.ServerPodStatus = model.WorkbenchServerPodStatus(k8sWorkbench.ServerPodStatus)
+		workbench.ServerPodMessage = model.WorbenchServerPodMessage(k8sWorkbench.ServerPodMessage)
+		workbench.K8sStatus = model.K8sWorkbenchStatus(k8sWorkbench.Status)
 
 		switch k8sWorkbench.Status {
 		case string(k8s.WorkbenchStatusServerStatusRunning):


### PR DESCRIPTION
This pull request updates the way the `SetClientWatchers` method in `workbench-service.go` handles workbench status updates from Kubernetes. Instead of always building a new workbench model from the Kubernetes event, the code now fetches the existing workbench from the database and only updates the relevant status fields. This ensures that any non-status fields already in the workbench are preserved.

**Workbench status update handling:**

* Changed the logic to fetch the existing `workbench` from the store using `GetWorkbench` before updating, rather than always constructing a new model from the Kubernetes event. This prevents overwriting non-status fields with potentially stale or missing data.
* Updated only the k8s-derived status fields (`ServerPodStatus`, `ServerPodMessage`, `K8sStatus`) on the fetched workbench, rather than building a new workbench model.