### PR TITLE
fix: update authz schema loading for superadmin scope

### DIFF
--- a/internal/api/v1/middleware/user-authorization.go
+++ b/internal/api/v1/middleware/user-authorization.go
@@ -146,16 +146,16 @@ func (c userControllerAuthorization) CreateUserRole(ctx context.Context, req *ch
 
 	roleName, err := authorization.ToRoleName(req.Role.Name)
 	if err != nil {
-		return nil, fmt.Errorf("invalid role name: %w", err)
+		return nil, cerr.ErrInvalidRequest.Wrap(err, "Invalid role name")
 	}
 	if c.IsRoleInScope(roleName, authorization.RoleScopeWorkspace, authorization.RoleScopeWorkbench) {
-		return nil, fmt.Errorf("role %q must be assigned through its scoped endpoint", roleName)
+		return nil, cerr.ErrInvalidRequest.WithMessage(fmt.Sprintf("Role %q must be assigned through its scoped endpoint", roleName))
 	}
 	assignmentContext := authorization.Context{authorization.RoleContextUser: fmt.Sprintf("%d", req.UserId)}
 	for key, value := range req.Role.Context {
 		dimension, err := authorization.ToRoleContext(key)
 		if err != nil {
-			return nil, fmt.Errorf("invalid role context: %w", err)
+			return nil, cerr.ErrInvalidRequest.Wrap(err, "Invalid role context")
 		}
 		assignmentContext[dimension] = value
 	}

--- a/internal/protocol/grpc/middleware/error.go
+++ b/internal/protocol/grpc/middleware/error.go
@@ -35,5 +35,13 @@ func UnaryErrorInterceptor(ctx context.Context, req interface{}, info *grpc.Unar
 		return nil, err // Already a gRPC error
 	}
 
-	return nil, cerr.ErrInternal.Wrap(err, "An unexpected error occurred.").ToGRPCStatus().Err()
+	wrapped := cerr.ErrInternal.Wrap(err, "An unexpected error occurred.")
+	logger.TechLog.Error(ctx, "request failed",
+		zap.String("method", info.FullMethod),
+		zap.String("code", wrapped.ChorusCode.String()),
+		zap.String("message", wrapped.Message),
+		zap.Error(err),
+		zap.String("stacktrace", wrapped.StackTrace()),
+	)
+	return nil, wrapped.ToGRPCStatus().Err()
 }

--- a/pkg/authorization/model/default_schema.go
+++ b/pkg/authorization/model/default_schema.go
@@ -441,13 +441,21 @@ func roleDefinition(name RoleName, description string, context map[ContextDimens
 }
 
 func inferRoleScope(context map[ContextDimension]ContextQuantifier) RoleScope {
-	if _, ok := context[RoleContextWorkbench]; ok {
+	_, hasUser := context[RoleContextUser]
+	_, hasWorkspace := context[RoleContextWorkspace]
+	_, hasWorkbench := context[RoleContextWorkbench]
+
+	// SuperAdmin carries all three dimensions
+	if hasUser && hasWorkspace && hasWorkbench {
+		return RoleScopeSystem
+	}
+	if hasWorkbench {
 		return RoleScopeWorkbench
 	}
-	if _, ok := context[RoleContextWorkspace]; ok {
+	if hasWorkspace {
 		return RoleScopeWorkspace
 	}
-	if _, ok := context[RoleContextUser]; ok {
+	if hasUser {
 		return RoleScopePlatform
 	}
 	return RoleScopePlatform


### PR DESCRIPTION
This pull request introduces improvements to error handling and logging, as well as refines the logic for inferring role scopes in the authorization model. The most significant changes are grouped below:

**Error Handling and Logging Enhancements:**

* The gRPC error interceptor (`internal/protocol/grpc/middleware/error.go`) now logs detailed error information—including method, code, message, original error, and stack trace—when an unexpected error occurs, improving observability and debugging.
* The user authorization controller (`internal/api/v1/middleware/user-authorization.go`) now uses structured error types (`cerr.ErrInvalidRequest`) for invalid role names and contexts, providing more consistent and informative error responses.

**Authorization Logic Improvements:**

* The `inferRoleScope` function (`pkg/authorization/model/default_schema.go`) has been updated to more accurately determine the role scope based on the presence of user, workspace, and workbench context dimensions. Notably, it now returns `RoleScopeSystem` when all three dimensions are present, ensuring correct scope assignment for SuperAdmin roles.