### PR TITLE
feat(app-sync): make labels fetching concurrent and fix apps insertion order

### DIFF
--- a/internal/client/harbor/harbor.go
+++ b/internal/client/harbor/harbor.go
@@ -17,7 +17,6 @@ type App struct {
 	Repository string            `json:"repository"`
 	Tag        string            `json:"tag"`
 	Labels     map[string]string `json:"labels"`
-	PushTime   time.Time         `json:"push_time"`
 }
 
 type HarborClient interface {
@@ -100,7 +99,6 @@ func (c *harborClient) ListApps() ([]App, error) {
 					Repository: repo.Name,
 					Tag:        tag.Name,
 					Labels:     labels,
-					PushTime:   tag.PushTime,
 				})
 			}
 		}

--- a/internal/client/harbor/harbor.go
+++ b/internal/client/harbor/harbor.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/client/docker"
 	"github.com/CHORUS-TRE/chorus-backend/internal/config"
+
+	"golang.org/x/sync/errgroup"
 )
 
 type App struct {
@@ -70,13 +72,24 @@ type harborTag struct {
 	PushTime time.Time `json:"push_time"`
 }
 
+// imageRef identifies one image whose labels must be retrieved.
+type imageRef struct {
+	repository   string // full repository name, used for the resulting App
+	strippedName string // project-prefix-stripped name, used to address the registry
+	digest       string
+	tags         []harborTag
+}
+
 func (c *harborClient) ListApps() ([]App, error) {
 	repos, err := c.listRepositories()
 	if err != nil {
 		return nil, fmt.Errorf("listing repositories: %w", err)
 	}
 
-	var apps []App
+	// Collect the set of images to fetch labels for. Listing artifacts is cheap
+	// and paginated, so it stays serial; the per-image label fetches below are
+	// the expensive part and run concurrently.
+	var refs []imageRef
 	for _, repo := range repos {
 		strippedName := c.stripProjectPrefix(repo.Name)
 		artifacts, err := c.listArtifacts(strippedName)
@@ -88,19 +101,44 @@ func (c *harborClient) ListApps() ([]App, error) {
 			if len(artifact.Tags) == 0 {
 				continue
 			}
+			refs = append(refs, imageRef{
+				repository:   repo.Name,
+				strippedName: strippedName,
+				digest:       artifact.Digest,
+				tags:         artifact.Tags,
+			})
+		}
+	}
 
-			labels, err := c.fetchLabels(strippedName, artifact.Digest)
+	// Fetch labels in parallel, bounded by max_parallel_fetches. Each fetch
+	// writes into its own slot, so the results need no locking.
+	labelsByRef := make([]map[string]string, len(refs))
+	g := new(errgroup.Group)
+	g.SetLimit(int(c.cfg.MaxParallelFetches))
+	for i := range refs {
+		i := i
+		ref := refs[i]
+		g.Go(func() error {
+			labels, err := c.fetchLabels(ref.strippedName, ref.digest)
 			if err != nil {
-				return nil, fmt.Errorf("fetching labels for %s@%s: %w", strippedName, artifact.Digest, err)
+				return fmt.Errorf("fetching labels for %s@%s: %w", ref.strippedName, ref.digest, err)
 			}
+			labelsByRef[i] = labels
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, err
+	}
 
-			for _, tag := range artifact.Tags {
-				apps = append(apps, App{
-					Repository: repo.Name,
-					Tag:        tag.Name,
-					Labels:     labels,
-				})
-			}
+	var apps []App
+	for i, ref := range refs {
+		for _, tag := range ref.tags {
+			apps = append(apps, App{
+				Repository: ref.repository,
+				Tag:        tag.Name,
+				Labels:     labelsByRef[i],
+			})
 		}
 	}
 

--- a/internal/cmd/provider/config.go
+++ b/internal/cmd/provider/config.go
@@ -150,6 +150,7 @@ func SetDefaultConfig(v *viper.Viper) {
 	v.SetDefault("clients.harbor_client.project", "apps")
 	v.SetDefault("clients.harbor_client.label_prefixes", []string{"ch.chorus-tre.", "org.opencontainers.image."})
 	v.SetDefault("clients.harbor_client.page_size", 100)
+	v.SetDefault("clients.harbor_client.max_parallel_fetches", 16)
 	v.SetDefault("clients.harbor_client.username", "robot$backend-apps-client")
 
 	// Loggers

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,13 +153,14 @@ type (
 	}
 
 	HarborClient struct {
-		Enabled       bool      `yaml:"enabled,omitempty"`
-		URL           string    `yaml:"url,omitempty"`
-		Username      string    `yaml:"username,omitempty"`
-		Password      Sensitive `yaml:"password,omitempty"`
-		Project       string    `yaml:"project,omitempty"`
-		LabelPrefixes []string  `yaml:"label_prefixes,omitempty"`
-		PageSize      int       `yaml:"page_size,omitempty"`
+		Enabled            bool      `yaml:"enabled,omitempty"`
+		URL                string    `yaml:"url,omitempty"`
+		Username           string    `yaml:"username,omitempty"`
+		Password           Sensitive `yaml:"password,omitempty"`
+		Project            string    `yaml:"project,omitempty"`
+		LabelPrefixes      []string  `yaml:"label_prefixes,omitempty"`
+		PageSize           int       `yaml:"page_size,omitempty"`
+		MaxParallelFetches uint64    `yaml:"max_parallel_fetches,omitempty"`
 	}
 
 	ImagePullSecret struct {

--- a/pkg/app/service/sync-job.go
+++ b/pkg/app/service/sync-job.go
@@ -114,9 +114,9 @@ func (j *AppSyncJob) Do(ctx context.Context, options map[string]interface{}) (st
 }
 
 func (j *AppSyncJob) appsToCreate(harborApps []harbor.App, existing map[string]struct{}, tenantID, userID uint64) []*model.App {
-	// Sort Harbor apps by push time, oldest first
+	// Sort Harbor apps by tag, highest version first.
 	sort.SliceStable(harborApps, func(i, k int) bool {
-		return harborApps[i].PushTime.Before(harborApps[k].PushTime)
+		return harborApps[i].Tag > harborApps[k].Tag
 	})
 
 	var toCreate []*model.App

--- a/pkg/app/service/sync-job.go
+++ b/pkg/app/service/sync-job.go
@@ -114,9 +114,9 @@ func (j *AppSyncJob) Do(ctx context.Context, options map[string]interface{}) (st
 }
 
 func (j *AppSyncJob) appsToCreate(harborApps []harbor.App, existing map[string]struct{}, tenantID, userID uint64) []*model.App {
-	// Sort Harbor apps by tag, highest version first.
+	// Sort Harbor apps by tag, lowest version first.
 	sort.SliceStable(harborApps, func(i, k int) bool {
-		return harborApps[i].Tag > harborApps[k].Tag
+		return harborApps[i].Tag < harborApps[k].Tag
 	})
 
 	var toCreate []*model.App

--- a/pkg/app/service/sync-job_test.go
+++ b/pkg/app/service/sync-job_test.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -139,25 +138,24 @@ func appLabels(name, category, title string) map[string]string {
 }
 
 func TestAppsToCreate(t *testing.T) {
-	now := time.Now()
 	j := &AppSyncJob{registry: testRegistry}
 
-	// Deliberately out of order; PushTime should drive creation order.
+	// Deliberately out of order; Tag should drive creation order.
 	harborApps := []harbor.App{
-		{Repository: "newer", Tag: "1", PushTime: now.Add(2 * time.Hour), Labels: appLabels("newer", "Development", "Newer")},
-		{Repository: "internal", Tag: "1", PushTime: now.Add(time.Hour), Labels: appLabels("internal", categoryChorus, "Internal")},
-		{Repository: "older", Tag: "1", PushTime: now, Labels: appLabels("older", "Science", "Older")},
-		{Repository: "dup", Tag: "1", PushTime: now.Add(3 * time.Hour), Labels: appLabels("dup", "Science", "Existing")},
+		{Repository: "newer", Tag: "2.0.0-1", Labels: appLabels("newer", "Development", "Newer")},
+		{Repository: "internal", Tag: "1.5.0-1", Labels: appLabels("internal", categoryChorus, "Internal")},
+		{Repository: "older", Tag: "1.0.0-1", Labels: appLabels("older", "Science", "Older")},
+		{Repository: "dup", Tag: "3.0.0-1", Labels: appLabels("dup", "Science", "Existing")},
 	}
 
 	existing := map[string]struct{}{
-		appIdentity(&model.App{DockerImageName: "dup", DockerImageTag: "1", Name: "Existing"}): {},
+		appIdentity(&model.App{DockerImageName: "dup", DockerImageTag: "3.0.0-1", Name: "Existing"}): {},
 	}
 
 	toCreate := j.appsToCreate(harborApps, existing, 1, 1)
 
 	// "internal" (chorus) and "dup" (already existing) are skipped; the rest are
-	// ordered oldest-first.
+	// ordered by tag.
 	require.Len(t, toCreate, 2)
 	assert.Equal(t, "Older", toCreate[0].Name)
 	assert.Equal(t, "Newer", toCreate[1].Name)


### PR DESCRIPTION
This pull request refactors how Harbor image labels are fetched and improves the performance and correctness of the app synchronization process. The most important changes are:

**Performance improvements (parallel label fetching):**
* Refactored `ListApps` in `harborClient` to fetch image labels concurrently using a bounded goroutine pool (`errgroup`), significantly speeding up label retrieval for large registries. The maximum parallel fetches is now configurable. [[1]](diffhunk://#diff-9f4172008fb24661b8a316628a03061a6dcc80718f54666b05395261b30ed91cR14-L20) [[2]](diffhunk://#diff-9f4172008fb24661b8a316628a03061a6dcc80718f54666b05395261b30ed91cR75-R92) [[3]](diffhunk://#diff-9f4172008fb24661b8a316628a03061a6dcc80718f54666b05395261b30ed91cR104-L107) [[4]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR163) [[5]](diffhunk://#diff-2807eaebdb9e2be5d50f7976b059711296bcf6fc261f1bc9955c3e0c10f206d5R153)

**Data model and configuration changes:**
* Removed the `PushTime` field from the `App` struct, as it is no longer used in the synchronization logic.
* Added a new configuration option `max_parallel_fetches` to control concurrency when fetching labels from Harbor. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR163) [[2]](diffhunk://#diff-2807eaebdb9e2be5d50f7976b059711296bcf6fc261f1bc9955c3e0c10f206d5R153)

**Sorting and test updates:**
* Changed the app creation logic to sort apps by tag (version) instead of push time, and updated related tests to match the new sorting behavior. [[1]](diffhunk://#diff-b1a9d5b6c56b76e3effc635fcc2acfbc94e62b188a50d615f0beb568c1c83778L117-R119) [[2]](diffhunk://#diff-4d6006793e146d02624f872fb9e106bf7a1a28dcaa307856f4e1f72d700096c9L142-R158)

These changes collectively improve the efficiency and maintainability of the Harbor client and app sync process.