### PR TITLE
fix(authorization): allow user managers to assign any role in the platform

### DIFF
--- a/internal/api/v1/middleware/user-authorization.go
+++ b/internal/api/v1/middleware/user-authorization.go
@@ -148,9 +148,7 @@ func (c userControllerAuthorization) CreateUserRole(ctx context.Context, req *ch
 	if err != nil {
 		return nil, cerr.ErrInvalidRequest.Wrap(err, "Invalid role name")
 	}
-	if c.IsRoleInScope(roleName, authorization.RoleScopeWorkspace, authorization.RoleScopeWorkbench) {
-		return nil, cerr.ErrInvalidRequest.WithMessage(fmt.Sprintf("Role %q must be assigned through its scoped endpoint", roleName))
-	}
+
 	assignmentContext := authorization.Context{authorization.RoleContextUser: fmt.Sprintf("%d", req.UserId)}
 	for key, value := range req.Role.Context {
 		dimension, err := authorization.ToRoleContext(key)

--- a/pkg/authorization/service/authorization.go
+++ b/pkg/authorization/service/authorization.go
@@ -268,10 +268,21 @@ func (s *authorizationService) CanAssignRole(user []model.Role, roleName model.R
 	if !ok {
 		return false, fmt.Errorf("role %q not found in schema", roleName)
 	}
+
+	// User-role managers may delegate any non-system role
+	if definition.Scope != model.RoleScopeSystem && s.canManageUserRoles(user) {
+		return true, nil
+	}
+
 	if err := s.ensureUserCanGrantPermissions(user, definition.Permissions, assignmentContext); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+func (s *authorizationService) canManageUserRoles(user []model.Role) bool {
+	allowed, err := s.IsUserAllowed(user, model.Permission{Name: model.PermissionManageUserRoles})
+	return err == nil && allowed
 }
 
 func (s *authorizationService) FindUsersWithPermission(ctx context.Context, tenantID uint64, filter model.FindUsersWithPermissionFilter) ([]uint64, error) {


### PR DESCRIPTION
This pull request updates the user role assignment logic to allow user-role managers to delegate any non-system role, improving flexibility in role management. The main changes involve relaxing previous restrictions on assigning scoped roles and introducing a new permission check for user-role managers.

**Authorization logic improvements:**

* User-role managers can now delegate any non-system role if they have the `PermissionManageUserRoles` permission, by adding a new check in `authorizationService.CanAssignRole`.
* Introduced the `authorizationService.canManageUserRoles` helper method to encapsulate the logic for checking the `PermissionManageUserRoles` permission.

**User role assignment endpoint changes:**

* Removed the restriction in `userControllerAuthorization.CreateUserRole` that prevented assigning workspace- or workbench-scoped roles through the generic endpoint, allowing for broader assignment as permitted by the new authorization logic.