### PR TITLE
feat(approval-request): use custom chorus errors and fix conflicting file error on transfer

### DIFF
--- a/internal/api/v1/approval-request-controller.go
+++ b/internal/api/v1/approval-request-controller.go
@@ -5,13 +5,10 @@ import (
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/chorus"
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/converter"
+	cerr "github.com/CHORUS-TRE/chorus-backend/internal/errors"
 	jwt_model "github.com/CHORUS-TRE/chorus-backend/internal/jwt/model"
-	"github.com/CHORUS-TRE/chorus-backend/internal/utils/grpc"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/approval-request/model"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/approval-request/service"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var _ chorus.ApprovalRequestServiceServer = (*ApprovalRequestController)(nil)
@@ -26,22 +23,22 @@ func NewApprovalRequestController(approvalRequest service.ApprovalRequester) App
 
 func (c ApprovalRequestController) GetApprovalRequest(ctx context.Context, req *chorus.GetApprovalRequestRequest) (*chorus.GetApprovalRequestReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	tenantID, err := jwt_model.ExtractTenantID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "could not extract tenant id from jwt-token")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Could not extract tenant ID from token")
 	}
 
 	request, err := c.approvalRequest.GetApprovalRequest(ctx, tenantID, req.Id)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'GetApprovalRequest': %v", err.Error())
+		return nil, err
 	}
 
 	protoRequest, err := converter.ApprovalRequestFromBusiness(request)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert approval request")
 	}
 
 	return &chorus.GetApprovalRequestReply{Result: &chorus.GetApprovalRequestResult{ApprovalRequest: protoRequest}}, nil
@@ -49,17 +46,17 @@ func (c ApprovalRequestController) GetApprovalRequest(ctx context.Context, req *
 
 func (c ApprovalRequestController) ListApprovalRequests(ctx context.Context, req *chorus.ListApprovalRequestsRequest) (*chorus.ListApprovalRequestsReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	tenantID, err := jwt_model.ExtractTenantID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "could not extract tenant id from jwt-token")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Could not extract tenant ID from token")
 	}
 
 	userID, err := jwt_model.ExtractUserID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "could not extract user id from jwt-token")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Could not extract user ID from token")
 	}
 
 	pagination := converter.PaginationToBusiness(req.Pagination)
@@ -96,14 +93,14 @@ func (c ApprovalRequestController) ListApprovalRequests(ctx context.Context, req
 
 	res, paginationRes, err := c.approvalRequest.ListApprovalRequests(ctx, tenantID, userID, &pagination, filter)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'ListApprovalRequests': %v", err.Error())
+		return nil, err
 	}
 
 	var requests []*chorus.ApprovalRequest
 	for _, r := range res {
 		protoRequest, err := converter.ApprovalRequestFromBusiness(r)
 		if err != nil {
-			return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+			return nil, cerr.ErrConversion.Wrap(err, "Failed to convert approval request")
 		}
 		requests = append(requests, protoRequest)
 	}
@@ -118,22 +115,22 @@ func (c ApprovalRequestController) ListApprovalRequests(ctx context.Context, req
 
 func (c ApprovalRequestController) CountMyApprovalRequests(ctx context.Context, req *chorus.CountMyApprovalRequestsRequest) (*chorus.CountMyApprovalRequestsReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	tenantID, err := jwt_model.ExtractTenantID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "could not extract tenant id from jwt-token")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Could not extract tenant ID from token")
 	}
 
 	userID, err := jwt_model.ExtractUserID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "could not extract user id from jwt-token")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Could not extract user ID from token")
 	}
 
 	counts, err := c.approvalRequest.CountMyApprovalRequests(ctx, tenantID, userID)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'CountMyApprovalRequests': %v", err.Error())
+		return nil, err
 	}
 
 	return &chorus.CountMyApprovalRequestsReply{
@@ -149,17 +146,17 @@ func (c ApprovalRequestController) CountMyApprovalRequests(ctx context.Context, 
 
 func (c ApprovalRequestController) CreateDataExtractionRequest(ctx context.Context, req *chorus.CreateDataExtractionRequestRequest) (*chorus.CreateDataExtractionRequestReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	tenantID, err := jwt_model.ExtractTenantID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "could not extract tenant id from jwt-token")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Could not extract tenant ID from token")
 	}
 
 	userID, err := jwt_model.ExtractUserID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "could not extract user id from jwt-token")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Could not extract user ID from token")
 	}
 
 	request := &model.ApprovalRequest{
@@ -176,12 +173,12 @@ func (c ApprovalRequestController) CreateDataExtractionRequest(ctx context.Conte
 
 	createdRequest, err := c.approvalRequest.CreateDataExtractionRequest(ctx, request, req.FilePaths)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'CreateDataExtractionRequest': %v", err.Error())
+		return nil, err
 	}
 
 	protoRequest, err := converter.ApprovalRequestFromBusiness(createdRequest)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert approval request")
 	}
 
 	return &chorus.CreateDataExtractionRequestReply{Result: &chorus.CreateDataExtractionRequestResult{ApprovalRequest: protoRequest}}, nil
@@ -189,17 +186,17 @@ func (c ApprovalRequestController) CreateDataExtractionRequest(ctx context.Conte
 
 func (c ApprovalRequestController) CreateDataTransferRequest(ctx context.Context, req *chorus.CreateDataTransferRequestRequest) (*chorus.CreateDataTransferRequestReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	tenantID, err := jwt_model.ExtractTenantID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "could not extract tenant id from jwt-token")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Could not extract tenant ID from token")
 	}
 
 	userID, err := jwt_model.ExtractUserID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "could not extract user id from jwt-token")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Could not extract user ID from token")
 	}
 
 	request := &model.ApprovalRequest{
@@ -217,12 +214,12 @@ func (c ApprovalRequestController) CreateDataTransferRequest(ctx context.Context
 
 	createdRequest, err := c.approvalRequest.CreateDataTransferRequest(ctx, request, req.FilePaths)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'CreateDataTransferRequest': %v", err.Error())
+		return nil, err
 	}
 
 	protoRequest, err := converter.ApprovalRequestFromBusiness(createdRequest)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert approval request")
 	}
 
 	return &chorus.CreateDataTransferRequestReply{Result: &chorus.CreateDataTransferRequestResult{ApprovalRequest: protoRequest}}, nil
@@ -230,27 +227,27 @@ func (c ApprovalRequestController) CreateDataTransferRequest(ctx context.Context
 
 func (c ApprovalRequestController) ApproveApprovalRequest(ctx context.Context, req *chorus.ApproveApprovalRequestRequest) (*chorus.ApproveApprovalRequestReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	tenantID, err := jwt_model.ExtractTenantID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "could not extract tenant id from jwt-token")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Could not extract tenant ID from token")
 	}
 
 	userID, err := jwt_model.ExtractUserID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "could not extract user id from jwt-token")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Could not extract user ID from token")
 	}
 
 	updatedRequest, err := c.approvalRequest.ApproveApprovalRequest(ctx, tenantID, req.Id, userID, req.Approve)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'ApproveApprovalRequest': %v", err.Error())
+		return nil, err
 	}
 
 	protoRequest, err := converter.ApprovalRequestFromBusiness(updatedRequest)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "conversion error: %v", err.Error())
+		return nil, cerr.ErrConversion.Wrap(err, "Failed to convert approval request")
 	}
 
 	return &chorus.ApproveApprovalRequestReply{Result: &chorus.ApproveApprovalRequestResult{ApprovalRequest: protoRequest}}, nil
@@ -258,22 +255,21 @@ func (c ApprovalRequestController) ApproveApprovalRequest(ctx context.Context, r
 
 func (c ApprovalRequestController) DeleteApprovalRequest(ctx context.Context, req *chorus.DeleteApprovalRequestRequest) (*chorus.DeleteApprovalRequestReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	tenantID, err := jwt_model.ExtractTenantID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "could not extract tenant id from jwt-token")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Could not extract tenant ID from token")
 	}
 
 	userID, err := jwt_model.ExtractUserID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "could not extract user id from jwt-token")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Could not extract user ID from token")
 	}
 
-	err = c.approvalRequest.DeleteApprovalRequest(ctx, tenantID, req.Id, userID)
-	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'DeleteApprovalRequest': %v", err.Error())
+	if err := c.approvalRequest.DeleteApprovalRequest(ctx, tenantID, req.Id, userID); err != nil {
+		return nil, err
 	}
 
 	return &chorus.DeleteApprovalRequestReply{Result: &chorus.DeleteApprovalRequestResult{}}, nil
@@ -281,17 +277,17 @@ func (c ApprovalRequestController) DeleteApprovalRequest(ctx context.Context, re
 
 func (c ApprovalRequestController) DownloadApprovalRequestFile(ctx context.Context, req *chorus.DownloadApprovalRequestFileRequest) (*chorus.DownloadApprovalRequestFileReply, error) {
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "empty request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Empty request")
 	}
 
 	tenantID, err := jwt_model.ExtractTenantID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "could not extract tenant id from jwt-token")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Could not extract tenant ID from token")
 	}
 
 	file, content, err := c.approvalRequest.DownloadApprovalRequestFile(ctx, tenantID, req.Id, req.Path)
 	if err != nil {
-		return nil, status.Errorf(grpc.ErrorCode(err), "unable to call 'DownloadApprovalRequestFile': %v", err.Error())
+		return nil, err
 	}
 
 	return &chorus.DownloadApprovalRequestFileReply{

--- a/internal/api/v1/middleware/approval-request-authorization.go
+++ b/internal/api/v1/middleware/approval-request-authorization.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"slices"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
-
 	"github.com/CHORUS-TRE/chorus-backend/internal/api/v1/chorus"
 	"github.com/CHORUS-TRE/chorus-backend/internal/config"
+	cerr "github.com/CHORUS-TRE/chorus-backend/internal/errors"
 	jwt_model "github.com/CHORUS-TRE/chorus-backend/internal/jwt/model"
 	"github.com/CHORUS-TRE/chorus-backend/internal/logger"
 	approval_request_model "github.com/CHORUS-TRE/chorus-backend/pkg/approval-request/model"
@@ -46,17 +44,17 @@ func ApprovalRequestAuthorizing(logger *logger.ContextLogger, authorizer authori
 func (c approvalRequestControllerAuthorization) GetApprovalRequest(ctx context.Context, req *chorus.GetApprovalRequestRequest) (*chorus.GetApprovalRequestReply, error) {
 	tenantID, err := jwt_model.ExtractTenantID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Unauthenticated, "unable to extract tenant ID")
+		return nil, cerr.ErrUnauthenticated.WithMessage("Unable to extract tenant ID")
 	}
 
 	userID, err := jwt_model.ExtractUserID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Unauthenticated, "unable to extract user ID")
+		return nil, cerr.ErrUnauthenticated.WithMessage("Unable to extract user ID")
 	}
 
 	approvalRequest, err := c.resolver.GetApprovalRequest(ctx, tenantID, req.Id)
 	if err != nil {
-		return nil, status.Error(codes.NotFound, "approval request not found")
+		return nil, cerr.ErrNotFound.WithMessage("Approval request not found")
 	}
 
 	// The requester and any designated approver can always view the request.
@@ -79,7 +77,7 @@ func (c approvalRequestControllerAuthorization) GetApprovalRequest(ctx context.C
 	}
 
 	if !isParticipant && !hasWorkspaceAccess() {
-		return nil, status.Error(codes.PermissionDenied, "user does not have permission to get this request")
+		return nil, cerr.ErrPermissionDenied.WithMessage("User does not have permission to get this request")
 	}
 
 	return c.next.GetApprovalRequest(ctx, req)
@@ -88,7 +86,7 @@ func (c approvalRequestControllerAuthorization) GetApprovalRequest(ctx context.C
 func (c approvalRequestControllerAuthorization) ListApprovalRequests(ctx context.Context, req *chorus.ListApprovalRequestsRequest) (*chorus.ListApprovalRequestsReply, error) {
 	userId, err := jwt_model.ExtractUserID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Unauthenticated, "unable to extract user ID")
+		return nil, cerr.ErrUnauthenticated.WithMessage("Unable to extract user ID")
 	}
 
 	listMine := false
@@ -154,12 +152,12 @@ func (c approvalRequestControllerAuthorization) CreateDataTransferRequest(ctx co
 func (c approvalRequestControllerAuthorization) ApproveApprovalRequest(ctx context.Context, req *chorus.ApproveApprovalRequestRequest) (*chorus.ApproveApprovalRequestReply, error) {
 	tenantID, err := jwt_model.ExtractTenantID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Unauthenticated, "unable to extract tenant ID")
+		return nil, cerr.ErrUnauthenticated.WithMessage("Unable to extract tenant ID")
 	}
 
 	approvalRequest, err := c.resolver.GetApprovalRequest(ctx, tenantID, req.Id)
 	if err != nil {
-		return nil, status.Error(codes.NotFound, "approval request not found")
+		return nil, cerr.ErrNotFound.WithMessage("Approval request not found")
 	}
 
 	// A user may approve a request if they hold the permission of at least
@@ -187,11 +185,11 @@ func (c approvalRequestControllerAuthorization) ApproveApprovalRequest(ctx conte
 			}
 		}
 	default:
-		return nil, status.Error(codes.Internal, "unable to determine source workspace for approval request")
+		return nil, cerr.ErrInternal.WithMessage("Unable to determine source workspace for approval request")
 	}
 
 	if !canApprove {
-		return nil, status.Error(codes.PermissionDenied, "user does not have permission to approve any pending step of this request")
+		return nil, cerr.ErrPermissionDenied.WithMessage("User does not have permission to approve any pending step of this request")
 	}
 
 	return c.next.ApproveApprovalRequest(ctx, req)
@@ -209,21 +207,21 @@ func (c approvalRequestControllerAuthorization) DeleteApprovalRequest(ctx contex
 func (c approvalRequestControllerAuthorization) DownloadApprovalRequestFile(ctx context.Context, req *chorus.DownloadApprovalRequestFileRequest) (*chorus.DownloadApprovalRequestFileReply, error) {
 	tenantID, err := jwt_model.ExtractTenantID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Unauthenticated, "unable to extract tenant ID")
+		return nil, cerr.ErrUnauthenticated.WithMessage("Unable to extract tenant ID")
 	}
 
 	userID, err := jwt_model.ExtractUserID(ctx)
 	if err != nil {
-		return nil, status.Error(codes.Unauthenticated, "unable to extract user ID")
+		return nil, cerr.ErrUnauthenticated.WithMessage("Unable to extract user ID")
 	}
 
 	approvalRequest, err := c.resolver.GetApprovalRequest(ctx, tenantID, req.Id)
 	if err != nil {
-		return nil, status.Error(codes.NotFound, "approval request not found")
+		return nil, cerr.ErrNotFound.WithMessage("Approval request not found")
 	}
 
 	if approvalRequest.Type != approval_request_model.ApprovalRequestTypeDataExtraction {
-		return nil, status.Error(codes.PermissionDenied, "only data extraction requests have downloadable files")
+		return nil, cerr.ErrPermissionDenied.WithMessage("Only data extraction requests have downloadable files")
 	}
 
 	workspaceID := approvalRequest.GetSourceWorkspaceID()
@@ -231,14 +229,14 @@ func (c approvalRequestControllerAuthorization) DownloadApprovalRequestFile(ctx 
 	isPotentialApprover := err == nil
 
 	if !isPotentialApprover && approvalRequest.RequesterID != userID {
-		return nil, status.Error(codes.PermissionDenied, "user does not have permission to download files for this request")
+		return nil, cerr.ErrPermissionDenied.WithMessage("User does not have permission to download files for this request")
 	}
 
 	// potential approvers should be able to download files even if the request is not yet approved, so that they can
 	// review the files before approving. However, non-approvers should not be able to download files for unapproved requests.
 	if approvalRequest.Status != approval_request_model.ApprovalRequestStatusApproved {
 		if !isPotentialApprover {
-			return nil, status.Error(codes.PermissionDenied, "request is not approved")
+			return nil, cerr.ErrPermissionDenied.WithMessage("Request is not approved")
 		}
 	}
 

--- a/pkg/approval-request/service/approval-request-service.go
+++ b/pkg/approval-request/service/approval-request-service.go
@@ -548,7 +548,8 @@ func (s *ApprovalRequestService) copyFilesToDestinationWorkspace(ctx context.Con
 
 		_, err = s.workspaceFileStore.CreateWorkspaceFile(ctx, details.DestinationWorkspaceID, destFile)
 		if err != nil {
-			if !strings.Contains(err.Error(), "a file already exists") {
+			var chorusErr *cerr.ChorusError
+			if !errors.As(err, &chorusErr) || chorusErr.ChorusCode != cerr.ErrAlreadyExists.ChorusCode {
 				return fmt.Errorf("unable to copy file to destination workspace: %w", err)
 			}
 

--- a/pkg/approval-request/service/approval-request-service.go
+++ b/pkg/approval-request/service/approval-request-service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path"
 	"strings"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/client/filestore"
 	"github.com/CHORUS-TRE/chorus-backend/internal/config"
+	cerr "github.com/CHORUS-TRE/chorus-backend/internal/errors"
 	"github.com/CHORUS-TRE/chorus-backend/internal/logger"
 	"github.com/CHORUS-TRE/chorus-backend/internal/utils/uuid"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/approval-request/model"
@@ -112,12 +114,12 @@ func (s *ApprovalRequestService) CreateDataExtractionRequest(ctx context.Context
 
 	details := request.Details.DataExtractionDetails
 	if details == nil {
-		return nil, fmt.Errorf("invalid details type for data extraction request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Invalid details type for data extraction request")
 	}
 
 	approversByStep, canAutoApprove, err := s.findApproversForDataExtractionRequest(ctx, request.TenantID, request.RequesterID, details.SourceWorkspaceID)
 	if err != nil {
-		return nil, fmt.Errorf("unable to find approvers: %w", err)
+		return nil, err
 	}
 
 	if canAutoApprove {
@@ -133,18 +135,18 @@ func (s *ApprovalRequestService) CreateDataExtractionRequest(ctx context.Context
 
 	createdRequest, err := s.store.CreateApprovalRequest(ctx, request.TenantID, request)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create approval request: %w", err)
+		return nil, cerr.WrapStoreError(err, "Unable to create approval request")
 	}
 
 	requestFiles, err := s.copyFilesToRequestStorage(ctx, createdRequest.ID, details.SourceWorkspaceID, filePaths)
 	if err != nil {
 		_ = s.store.DeleteApprovalRequest(ctx, request.TenantID, createdRequest.ID)
-		return nil, fmt.Errorf("unable to copy files to request storage: %w", err)
+		return nil, err
 	}
 
 	createdDetails := createdRequest.Details.DataExtractionDetails
 	if createdDetails == nil {
-		return nil, fmt.Errorf("invalid details type for data extraction request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Invalid details type for data extraction request")
 	}
 	createdDetails.Files = requestFiles
 
@@ -152,7 +154,7 @@ func (s *ApprovalRequestService) CreateDataExtractionRequest(ctx context.Context
 	if err != nil {
 		_ = s.cleanupRequestStorage(ctx, createdRequest.ID)
 		_ = s.store.DeleteApprovalRequest(ctx, request.TenantID, createdRequest.ID)
-		return nil, fmt.Errorf("unable to update request with files: %w", err)
+		return nil, cerr.WrapStoreError(err, "Unable to update approval request with files")
 	}
 
 	for _, approverID := range uniqueApproverIDs(approversByStep) {
@@ -191,14 +193,14 @@ func (s *ApprovalRequestService) findApproversForDataExtractionRequest(ctx conte
 
 	approvers, err := s.userPermissionFinder.FindUsersWithPermission(ctx, tenantID, filter)
 	if err != nil {
-		return nil, false, fmt.Errorf("unable to find approvers: %w", err)
+		return nil, false, err
 	}
 
 	if len(approvers) == 0 {
 		if s.cfg.Services.ApprovalRequestService.RequireDataManagerApproval {
-			return nil, false, fmt.Errorf("no workspace data manager found for this workspace; please assign a data manager before creating approval requests")
+			return nil, false, cerr.ErrInvalidRequest.WithMessage("No workspace data manager found for this workspace; please assign a data manager before creating approval requests")
 		}
-		return nil, false, fmt.Errorf("no users with approval permission found for this workspace")
+		return nil, false, cerr.ErrInvalidRequest.WithMessage("No users with approval permission found for this workspace")
 	}
 
 	requesterCanApprove := containsID(approvers, requesterID)
@@ -223,16 +225,16 @@ func (s *ApprovalRequestService) CreateDataTransferRequest(ctx context.Context, 
 
 	details := request.Details.DataTransferDetails
 	if details == nil {
-		return nil, fmt.Errorf("invalid details type for data transfer request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Invalid details type for data transfer request")
 	}
 
 	if details.DestinationWorkspaceID == 0 {
-		return nil, fmt.Errorf("destination workspace ID is required for data transfer requests")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Destination workspace ID is required for data transfer requests")
 	}
 
 	approversByStep, canAutoApprove, err := s.findApproversForDataTransferRequest(ctx, request.TenantID, request.RequesterID, details.SourceWorkspaceID, details.DestinationWorkspaceID)
 	if err != nil {
-		return nil, fmt.Errorf("unable to find approvers: %w", err)
+		return nil, err
 	}
 
 	if canAutoApprove {
@@ -248,18 +250,18 @@ func (s *ApprovalRequestService) CreateDataTransferRequest(ctx context.Context, 
 
 	createdRequest, err := s.store.CreateApprovalRequest(ctx, request.TenantID, request)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create approval request: %w", err)
+		return nil, cerr.WrapStoreError(err, "Unable to create approval request")
 	}
 
 	requestFiles, err := s.copyFilesToRequestStorage(ctx, createdRequest.ID, details.SourceWorkspaceID, filePaths)
 	if err != nil {
 		_ = s.store.DeleteApprovalRequest(ctx, request.TenantID, createdRequest.ID)
-		return nil, fmt.Errorf("unable to copy files to request storage: %w", err)
+		return nil, err
 	}
 
 	createdDetails := createdRequest.Details.DataTransferDetails
 	if createdDetails == nil {
-		return nil, fmt.Errorf("invalid details type for data transfer request")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Invalid details type for data transfer request")
 	}
 	createdDetails.Files = requestFiles
 
@@ -267,12 +269,12 @@ func (s *ApprovalRequestService) CreateDataTransferRequest(ctx context.Context, 
 	if err != nil {
 		_ = s.cleanupRequestStorage(ctx, createdRequest.ID)
 		_ = s.store.DeleteApprovalRequest(ctx, request.TenantID, createdRequest.ID)
-		return nil, fmt.Errorf("unable to update request with files: %w", err)
+		return nil, cerr.WrapStoreError(err, "Unable to update approval request with files")
 	}
 
 	if canAutoApprove {
 		if err := s.executeApprovedRequest(ctx, updatedRequest); err != nil {
-			return nil, fmt.Errorf("unable to execute auto-approved request: %w", err)
+			return nil, err
 		}
 	}
 
@@ -312,7 +314,7 @@ func (s *ApprovalRequestService) findApproversForDataTransferRequest(ctx context
 
 	downloadApprovers, err := s.userPermissionFinder.FindUsersWithPermission(ctx, tenantID, filterDownload)
 	if err != nil {
-		return nil, false, fmt.Errorf("unable to find approvers: %w", err)
+		return nil, false, err
 	}
 
 	filterUpload := authorization_model.FindUsersWithPermissionFilter{
@@ -322,17 +324,17 @@ func (s *ApprovalRequestService) findApproversForDataTransferRequest(ctx context
 
 	uploadApprovers, err := s.userPermissionFinder.FindUsersWithPermission(ctx, tenantID, filterUpload)
 	if err != nil {
-		return nil, false, fmt.Errorf("unable to find approvers: %w", err)
+		return nil, false, err
 	}
 
 	if len(downloadApprovers) == 0 {
 		if s.cfg.Services.ApprovalRequestService.RequireDataManagerApproval {
-			return nil, false, fmt.Errorf("no workspace data manager found for the source workspace; please assign a data manager before creating approval requests")
+			return nil, false, cerr.ErrInvalidRequest.WithMessage("No workspace data manager found for the source workspace; please assign a data manager before creating approval requests")
 		}
-		return nil, false, fmt.Errorf("no users with download approval permission found for the source workspace")
+		return nil, false, cerr.ErrInvalidRequest.WithMessage("No users with download approval permission found for the source workspace")
 	}
 	if len(uploadApprovers) == 0 {
-		return nil, false, fmt.Errorf("no users with upload approval permission found for the destination workspace")
+		return nil, false, cerr.ErrInvalidRequest.WithMessage("No users with upload approval permission found for the destination workspace")
 	}
 
 	// The requester may self-approve only if they are authorized for every step.
@@ -373,18 +375,18 @@ func uniqueApproverIDs(approversByStep map[model.ApprovalStep][]uint64) []uint64
 func (s *ApprovalRequestService) ApproveApprovalRequest(ctx context.Context, tenantID, requestID, userID uint64, approve bool) (*model.ApprovalRequest, error) {
 	request, err := s.store.GetApprovalRequest(ctx, tenantID, requestID)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get request: %w", err)
+		return nil, cerr.WrapStoreError(err, "Unable to get approval request")
 	}
 
 	if request.Status != model.ApprovalRequestStatusPending {
-		return nil, fmt.Errorf("request is not pending approval")
+		return nil, cerr.ErrInvalidRequest.WithMessage("Request is not pending approval")
 	}
 
 	// Determine which steps this user is entitled to decide on (and that have
 	// not already been decided). If empty, the user cannot act on this request.
 	stepsToDecide := request.StepsToApprove(userID)
 	if len(stepsToDecide) == 0 {
-		return nil, fmt.Errorf("user is not authorized to approve any pending step of this request")
+		return nil, cerr.ErrPermissionDenied.WithMessage("User is not authorized to approve any pending step of this request")
 	}
 
 	if request.StepDecisions == nil {
@@ -418,12 +420,12 @@ func (s *ApprovalRequestService) ApproveApprovalRequest(ctx context.Context, ten
 
 	updatedRequest, err := s.store.UpdateApprovalRequest(ctx, tenantID, request)
 	if err != nil {
-		return nil, fmt.Errorf("unable to update request: %w", err)
+		return nil, cerr.WrapStoreError(err, "Unable to update approval request")
 	}
 
 	if updatedRequest.Status == model.ApprovalRequestStatusApproved {
 		if err := s.executeApprovedRequest(ctx, updatedRequest); err != nil {
-			return nil, fmt.Errorf("unable to execute approved request: %w", err)
+			return nil, err
 		}
 	}
 
@@ -452,18 +454,21 @@ func (s *ApprovalRequestService) ApproveApprovalRequest(ctx context.Context, ten
 func (s *ApprovalRequestService) DeleteApprovalRequest(ctx context.Context, tenantID, requestID, userID uint64) error {
 	request, err := s.store.GetApprovalRequest(ctx, tenantID, requestID)
 	if err != nil {
-		return fmt.Errorf("unable to get request: %w", err)
+		return cerr.WrapStoreError(err, "Unable to get approval request")
 	}
 
 	if !request.CanBeDeletedBy(userID) {
-		return fmt.Errorf("user is not authorized to delete this request")
+		return cerr.ErrPermissionDenied.WithMessage("User is not authorized to delete this request")
 	}
 
 	if err := s.cleanupRequestStorage(ctx, requestID); err != nil {
-		return fmt.Errorf("unable to cleanup request storage: %w", err)
+		return err
 	}
 
-	return s.store.DeleteApprovalRequest(ctx, tenantID, requestID)
+	if err := s.store.DeleteApprovalRequest(ctx, tenantID, requestID); err != nil {
+		return cerr.WrapStoreError(err, "Unable to delete approval request")
+	}
+	return nil
 }
 
 // copyFilesToRequestStorage copies files from the source workspace into the
@@ -480,11 +485,11 @@ func (s *ApprovalRequestService) copyFilesToRequestStorage(ctx context.Context, 
 
 		file, err := s.workspaceFileStore.GetWorkspaceFileWithContent(ctx, sourceWorkspaceID, filePath)
 		if err != nil {
-			return nil, fmt.Errorf("unable to get source file %s: %w", filePath, err)
+			return nil, err
 		}
 
 		if file.IsDirectory {
-			return nil, fmt.Errorf("directories are not supported: %s", filePath)
+			return nil, cerr.ErrInvalidRequest.WithMessage(fmt.Sprintf("Directories are not supported: %s", filePath))
 		}
 
 		destFile := &filestore.File{
@@ -495,7 +500,7 @@ func (s *ApprovalRequestService) copyFilesToRequestStorage(ctx context.Context, 
 
 		_, err = s.stagingFileStore.CreateFile(ctx, destFile)
 		if err != nil {
-			return nil, fmt.Errorf("unable to copy file %s to request storage: %w", filePath, err)
+			return nil, cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to copy file %s to request storage", filePath))
 		}
 
 		requestFiles = append(requestFiles, model.ApprovalRequestFile{
@@ -510,7 +515,10 @@ func (s *ApprovalRequestService) copyFilesToRequestStorage(ctx context.Context, 
 
 func (s *ApprovalRequestService) cleanupRequestStorage(ctx context.Context, requestID uint64) error {
 	requestDir := model.GetApprovalRequestStoragePath(requestID)
-	return s.stagingFileStore.DeleteDirectory(ctx, requestDir)
+	if err := s.stagingFileStore.DeleteDirectory(ctx, requestDir); err != nil {
+		return cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to cleanup request storage for request %d", requestID))
+	}
+	return nil
 }
 
 func (s *ApprovalRequestService) executeApprovedRequest(ctx context.Context, request *model.ApprovalRequest) error {
@@ -521,11 +529,11 @@ func (s *ApprovalRequestService) executeApprovedRequest(ctx context.Context, req
 	case model.ApprovalRequestTypeDataTransfer:
 		details := request.Details.DataTransferDetails
 		if details == nil {
-			return fmt.Errorf("invalid details type for data transfer request")
+			return cerr.ErrInvalidRequest.WithMessage("Invalid details type for data transfer request")
 		}
 		return s.copyFilesToDestinationWorkspace(ctx, *details)
 	default:
-		return fmt.Errorf("unsupported request type: %s", request.Type)
+		return cerr.ErrInvalidRequest.WithMessage(fmt.Sprintf("Unsupported request type: %s", request.Type))
 	}
 }
 
@@ -537,7 +545,7 @@ func (s *ApprovalRequestService) copyFilesToDestinationWorkspace(ctx context.Con
 	for _, reqFile := range details.Files {
 		file, err := s.stagingFileStore.GetFile(ctx, reqFile.DestinationPath)
 		if err != nil {
-			return fmt.Errorf("unable to get file from request storage %s: %w", reqFile.DestinationPath, err)
+			return cerr.ErrInternal.Wrap(err, fmt.Sprintf("Unable to get file from request storage %s", reqFile.DestinationPath))
 		}
 
 		destFile := &filestore.File{
@@ -550,7 +558,7 @@ func (s *ApprovalRequestService) copyFilesToDestinationWorkspace(ctx context.Con
 		if err != nil {
 			var chorusErr *cerr.ChorusError
 			if !errors.As(err, &chorusErr) || chorusErr.ChorusCode != cerr.ErrAlreadyExists.ChorusCode {
-				return fmt.Errorf("unable to copy file to destination workspace: %w", err)
+				return err
 			}
 
 			destFile.Path = appendUUIDToFilename(destFile.Path)
@@ -559,7 +567,7 @@ func (s *ApprovalRequestService) copyFilesToDestinationWorkspace(ctx context.Con
 
 			_, err = s.workspaceFileStore.CreateWorkspaceFile(ctx, details.DestinationWorkspaceID, destFile)
 			if err != nil {
-				return fmt.Errorf("unable to copy file to destination workspace: %w", err)
+				return err
 			}
 		}
 	}
@@ -578,16 +586,16 @@ func appendUUIDToFilename(filePath string) string {
 func (s *ApprovalRequestService) DownloadApprovalRequestFile(ctx context.Context, tenantID, requestID uint64, filePath string) (*model.ApprovalRequestFile, []byte, error) {
 	request, err := s.store.GetApprovalRequest(ctx, tenantID, requestID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to get request: %w", err)
+		return nil, nil, cerr.WrapStoreError(err, "Unable to get approval request")
 	}
 
 	if request.Type != model.ApprovalRequestTypeDataExtraction {
-		return nil, nil, fmt.Errorf("download is only available for data extraction requests")
+		return nil, nil, cerr.ErrInvalidRequest.WithMessage("Download is only available for data extraction requests")
 	}
 
 	details := request.Details.DataExtractionDetails
 	if details == nil {
-		return nil, nil, fmt.Errorf("invalid request details")
+		return nil, nil, cerr.ErrInvalidRequest.WithMessage("Invalid request details")
 	}
 
 	var requestFile *model.ApprovalRequestFile
@@ -599,12 +607,12 @@ func (s *ApprovalRequestService) DownloadApprovalRequestFile(ctx context.Context
 	}
 
 	if requestFile == nil {
-		return nil, nil, fmt.Errorf("file not found in request")
+		return nil, nil, cerr.ErrNotFound.WithMessage("File not found in request")
 	}
 
 	file, err := s.stagingFileStore.GetFile(ctx, requestFile.DestinationPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to get file from staging storage: %w", err)
+		return nil, nil, cerr.ErrInternal.Wrap(err, "Unable to get file from staging storage")
 	}
 
 	return requestFile, file.Content, nil

--- a/pkg/approval-request/service/middleware/logging.go
+++ b/pkg/approval-request/service/middleware/logging.go
@@ -2,7 +2,6 @@ package middleware
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/logger"
@@ -37,7 +36,7 @@ func (c approvalRequestServiceLogging) GetApprovalRequest(ctx context.Context, t
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return nil, fmt.Errorf("unable to get approval request: %w", err)
+		return nil, err
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -56,7 +55,7 @@ func (c approvalRequestServiceLogging) ListApprovalRequests(ctx context.Context,
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return nil, nil, fmt.Errorf("unable to list approval requests: %w", err)
+		return nil, nil, err
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -75,7 +74,7 @@ func (c approvalRequestServiceLogging) CountMyApprovalRequests(ctx context.Conte
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return nil, fmt.Errorf("unable to count my approval requests: %w", err)
+		return nil, err
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -94,7 +93,7 @@ func (c approvalRequestServiceLogging) CreateDataExtractionRequest(ctx context.C
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return nil, fmt.Errorf("unable to create data extraction request: %w", err)
+		return nil, err
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -113,7 +112,7 @@ func (c approvalRequestServiceLogging) CreateDataTransferRequest(ctx context.Con
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return nil, fmt.Errorf("unable to create data transfer request: %w", err)
+		return nil, err
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -134,7 +133,7 @@ func (c approvalRequestServiceLogging) ApproveApprovalRequest(ctx context.Contex
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return nil, fmt.Errorf("unable to approve approval request: %w", err)
+		return nil, err
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -155,7 +154,7 @@ func (c approvalRequestServiceLogging) DeleteApprovalRequest(ctx context.Context
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return fmt.Errorf("unable to delete approval request: %w", err)
+		return err
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,
@@ -176,7 +175,7 @@ func (c approvalRequestServiceLogging) DownloadApprovalRequestFile(ctx context.C
 			zap.Error(err),
 			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
 		)
-		return nil, nil, fmt.Errorf("unable to download approval request file: %w", err)
+		return nil, nil, err
 	}
 
 	c.logger.Info(ctx, logger.LoggerMessageRequestCompleted,

--- a/pkg/approval-request/service/middleware/validation.go
+++ b/pkg/approval-request/service/middleware/validation.go
@@ -3,10 +3,10 @@ package middleware
 import (
 	"context"
 
+	cerr "github.com/CHORUS-TRE/chorus-backend/internal/errors"
 	"github.com/CHORUS-TRE/chorus-backend/pkg/approval-request/model"
 	approval_request_service "github.com/CHORUS-TRE/chorus-backend/pkg/approval-request/service"
 	common_model "github.com/CHORUS-TRE/chorus-backend/pkg/common/model"
-	service "github.com/CHORUS-TRE/chorus-backend/pkg/common/service"
 
 	val "github.com/go-playground/validator/v10"
 )
@@ -27,14 +27,14 @@ func Validation(validate *val.Validate) func(approval_request_service.ApprovalRe
 
 func (v validation) GetApprovalRequest(ctx context.Context, tenantID, requestID uint64) (*model.ApprovalRequest, error) {
 	if requestID == 0 {
-		return nil, &service.InvalidParametersErr{}
+		return nil, cerr.ErrValidation.WithMessage("Request ID is required")
 	}
 	return v.next.GetApprovalRequest(ctx, tenantID, requestID)
 }
 
 func (v validation) ListApprovalRequests(ctx context.Context, tenantID, userID uint64, pagination *common_model.Pagination, filter approval_request_service.ApprovalRequestFilter) ([]*model.ApprovalRequest, *common_model.PaginationResult, error) {
 	if err := v.validate.Struct(pagination); err != nil {
-		return nil, nil, err
+		return nil, nil, cerr.WrapValidationError(err)
 	}
 	return v.next.ListApprovalRequests(ctx, tenantID, userID, pagination, filter)
 }
@@ -45,61 +45,61 @@ func (v validation) CountMyApprovalRequests(ctx context.Context, tenantID, userI
 
 func (v validation) CreateDataExtractionRequest(ctx context.Context, request *model.ApprovalRequest, filePaths []string) (*model.ApprovalRequest, error) {
 	if request == nil {
-		return nil, &service.InvalidParametersErr{}
+		return nil, cerr.ErrValidation.WithMessage("Request is required")
 	}
 	details := request.Details.DataExtractionDetails
 	if details == nil {
-		return nil, &service.InvalidParametersErr{}
+		return nil, cerr.ErrValidation.WithMessage("Data extraction details are required")
 	}
 	if details.SourceWorkspaceID == 0 {
-		return nil, &service.InvalidParametersErr{}
+		return nil, cerr.ErrValidation.WithMessage("Source workspace ID is required")
 	}
 	if len(filePaths) == 0 {
-		return nil, &service.InvalidParametersErr{}
+		return nil, cerr.ErrValidation.WithMessage("At least one file path is required")
 	}
 	return v.next.CreateDataExtractionRequest(ctx, request, filePaths)
 }
 
 func (v validation) CreateDataTransferRequest(ctx context.Context, request *model.ApprovalRequest, filePaths []string) (*model.ApprovalRequest, error) {
 	if request == nil {
-		return nil, &service.InvalidParametersErr{}
+		return nil, cerr.ErrValidation.WithMessage("Request is required")
 	}
 	details := request.Details.DataTransferDetails
 	if details == nil {
-		return nil, &service.InvalidParametersErr{}
+		return nil, cerr.ErrValidation.WithMessage("Data transfer details are required")
 	}
 	if details.SourceWorkspaceID == 0 {
-		return nil, &service.InvalidParametersErr{}
+		return nil, cerr.ErrValidation.WithMessage("Source workspace ID is required")
 	}
 	if details.DestinationWorkspaceID == 0 {
-		return nil, &service.InvalidParametersErr{}
+		return nil, cerr.ErrValidation.WithMessage("Destination workspace ID is required")
 	}
 	if len(filePaths) == 0 {
-		return nil, &service.InvalidParametersErr{}
+		return nil, cerr.ErrValidation.WithMessage("At least one file path is required")
 	}
 	return v.next.CreateDataTransferRequest(ctx, request, filePaths)
 }
 
 func (v validation) ApproveApprovalRequest(ctx context.Context, tenantID, requestID, userID uint64, approve bool) (*model.ApprovalRequest, error) {
 	if requestID == 0 {
-		return nil, &service.InvalidParametersErr{}
+		return nil, cerr.ErrValidation.WithMessage("Request ID is required")
 	}
 	return v.next.ApproveApprovalRequest(ctx, tenantID, requestID, userID, approve)
 }
 
 func (v validation) DeleteApprovalRequest(ctx context.Context, tenantID, requestID, userID uint64) error {
 	if requestID == 0 {
-		return &service.InvalidParametersErr{}
+		return cerr.ErrValidation.WithMessage("Request ID is required")
 	}
 	return v.next.DeleteApprovalRequest(ctx, tenantID, requestID, userID)
 }
 
 func (v validation) DownloadApprovalRequestFile(ctx context.Context, tenantID, requestID uint64, filePath string) (*model.ApprovalRequestFile, []byte, error) {
 	if requestID == 0 {
-		return nil, nil, &service.InvalidParametersErr{}
+		return nil, nil, cerr.ErrValidation.WithMessage("Request ID is required")
 	}
 	if filePath == "" {
-		return nil, nil, &service.InvalidParametersErr{}
+		return nil, nil, cerr.ErrValidation.WithMessage("File path is required")
 	}
 	return v.next.DownloadApprovalRequestFile(ctx, tenantID, requestID, filePath)
 }


### PR DESCRIPTION
This pull request refactors error handling for approval request APIs and middleware to use a centralized error package (`cerr`) instead of direct gRPC status errors. This change improves consistency, maintainability, and the clarity of error messages across the codebase. The update touches both controller and middleware layers, ensuring all error responses are standardized.

**Error handling improvements:**

- All controller methods in `approval-request-controller.go` now return errors using the custom `cerr` package (e.g., `cerr.ErrInvalidRequest`, `cerr.ErrConversion`, etc.) instead of `status.Error` or `status.Errorf`. This provides more consistent and descriptive error handling. [[1]](diffhunk://#diff-375153429a55c2466177dd8780b08df82f8848c9703cd5f9bc9a94767fdfcbb3L29-R59) [[2]](diffhunk://#diff-375153429a55c2466177dd8780b08df82f8848c9703cd5f9bc9a94767fdfcbb3L99-R103) [[3]](diffhunk://#diff-375153429a55c2466177dd8780b08df82f8848c9703cd5f9bc9a94767fdfcbb3L121-R133) [[4]](diffhunk://#diff-375153429a55c2466177dd8780b08df82f8848c9703cd5f9bc9a94767fdfcbb3L152-R159) [[5]](diffhunk://#diff-375153429a55c2466177dd8780b08df82f8848c9703cd5f9bc9a94767fdfcbb3L179-R199) [[6]](diffhunk://#diff-375153429a55c2466177dd8780b08df82f8848c9703cd5f9bc9a94767fdfcbb3L220-R290) [[7]](diffhunk://#diff-375153429a55c2466177dd8780b08df82f8848c9703cd5f9bc9a94767fdfcbb3L152-R159)
- The middleware in `approval-request-authorization.go` also switches to using the `cerr` package for all error responses, replacing gRPC status errors with centralized error types and custom messages. [[1]](diffhunk://#diff-8af302f9c258d96848ecf625aa5b1f3c71345df635a896c5b263926175e05481L49-R57) [[2]](diffhunk://#diff-8af302f9c258d96848ecf625aa5b1f3c71345df635a896c5b263926175e05481L82-R80) [[3]](diffhunk://#diff-8af302f9c258d96848ecf625aa5b1f3c71345df635a896c5b263926175e05481L91-R89) [[4]](diffhunk://#diff-8af302f9c258d96848ecf625aa5b1f3c71345df635a896c5b263926175e05481L157-R160) [[5]](diffhunk://#diff-8af302f9c258d96848ecf625aa5b1f3c71345df635a896c5b263926175e05481L190-R192) [[6]](diffhunk://#diff-8af302f9c258d96848ecf625aa5b1f3c71345df635a896c5b263926175e05481L212-R239)

**Code cleanup and consistency:**

- Removed unused gRPC imports (`codes`, `status`) from affected files, since error handling is now abstracted through the `cerr` package. [[1]](diffhunk://#diff-375153429a55c2466177dd8780b08df82f8848c9703cd5f9bc9a94767fdfcbb3R8-L14) [[2]](diffhunk://#diff-8af302f9c258d96848ecf625aa5b1f3c71345df635a896c5b263926175e05481L7-R9)
- Updated the service layer (`approval-request-service.go`) to use `cerr.ErrInvalidRequest` for validation errors and to propagate errors directly, further unifying error handling. [[1]](diffhunk://#diff-43e688874e9ac2c7ee7b8e9d232cc348f1ecfe1f53bc8a43f96e96d6d11c2f40R5-R13) [[2]](diffhunk://#diff-43e688874e9ac2c7ee7b8e9d232cc348f1ecfe1f53bc8a43f96e96d6d11c2f40L115-R122)

These changes make error responses more uniform and easier to manage, and pave the way for improved logging, error tracking, and client-side error handling.