### PR TITLE
fix(approval-request): add data manager permission to list requests

### DIFF
--- a/pkg/approval-request/store/postgres/approval-request-store_integration_test.go
+++ b/pkg/approval-request/store/postgres/approval-request-store_integration_test.go
@@ -198,8 +198,8 @@ func TestApprovalRequestStorage_ListApprovalRequests_WithApproverAndRequesterFil
 	require.Equal(t, uint64(1), pagination.Total)
 	require.Equal(t, request1.ID, requests[0].ID)
 
-	sourceWorkspaceID := uint64(202)
-	requests, _, err = store.ListApprovalRequests(ctx, fixtures.tenantID, fixtures.userIDs["alice"], nil, approval_request_service.ApprovalRequestFilter{SourceWorkspaceID: &sourceWorkspaceID})
+	workspaceID := uint64(202)
+	requests, _, err = store.ListApprovalRequests(ctx, fixtures.tenantID, fixtures.userIDs["alice"], nil, approval_request_service.ApprovalRequestFilter{WorkspaceID: &workspaceID})
 	require.NoError(t, err)
 	require.Len(t, requests, 1)
 	require.Equal(t, request2.ID, requests[0].ID)

--- a/pkg/authorization/model/default_schema.go
+++ b/pkg/authorization/model/default_schema.go
@@ -80,6 +80,7 @@ func GetDefaultSchema() AuthorizationSchema {
 			PermissionDownloadFilesFromWorkspace,
 			PermissionManageUsersDataRoleInWorkspace,
 			PermissionCreateRequest,
+			PermissionListRequests,
 		},
 	)
 


### PR DESCRIPTION
This pull request introduces a minor update to permissions and a small test adjustment for approval request filtering. The main changes are:

**Authorization permissions:**

* Added `PermissionListRequests` to the default authorization schema, which expands the set of actions users can perform by default.

**Approval request filtering:**

* Updated the integration test to use the `WorkspaceID` filter instead of `SourceWorkspaceID` when listing approval requests, improving clarity and alignment with the filter's intended usage.