### PR TITLE
fix: call the RunE function from cobra's startCmd

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -38,7 +38,7 @@ var rootCmd = &cobra.Command{
 	Use:   componentName,
 	Short: descriptionShort,
 	Long:  descriptionLong,
-	Run:   startCmd.Run,
+	RunE:  startCmd.RunE,
 }
 
 func init() {


### PR DESCRIPTION
The rootCmd was calling a non existing function