### PR TITLE
Fix/rework authenticated permissions

### DIFF
--- a/internal/migration/chorus/postgres/00047_authorization_platformworkspacemanager.sql
+++ b/internal/migration/chorus/postgres/00047_authorization_platformworkspacemanager.sql
@@ -1,0 +1,7 @@
+-- +migrate Up
+
+-- +migrate StatementBegin
+INSERT INTO role_definitions (name) VALUES
+('PlatformWorkspaceManager')
+ON CONFLICT (name) DO NOTHING;
+-- +migrate StatementEnd

--- a/internal/migration/chorus/postgres/00047_authorization_platformworkspacemanager.sql
+++ b/internal/migration/chorus/postgres/00047_authorization_platformworkspacemanager.sql
@@ -1,7 +1,0 @@
--- +migrate Up
-
--- +migrate StatementBegin
-INSERT INTO role_definitions (name) VALUES
-('PlatformWorkspaceManager')
-ON CONFLICT (name) DO NOTHING;
--- +migrate StatementEnd

--- a/pkg/authorization/model/default_schema.go
+++ b/pkg/authorization/model/default_schema.go
@@ -25,7 +25,6 @@ func GetDefaultSchema() AuthorizationSchema {
 			PermissionEnableTotp,
 			PermissionResetTotp,
 			PermissionResetPassword,
-			PermissionCreateWorkspace,
 			PermissionListWorkspaces,
 			PermissionListPublicWorkspaces,
 			PermissionListWorkbenchs,
@@ -185,6 +184,13 @@ func GetDefaultSchema() AuthorizationSchema {
 		},
 	)
 
+	platformWorkspaceManagerPermissions := permissionList(
+		authenticatedPermissions,
+		[]PermissionName{
+			PermissionCreateWorkspace,
+		},
+	)
+
 	appStoreAdminPermissions := permissionList(
 		authenticatedPermissions,
 		[]PermissionName{
@@ -220,6 +226,7 @@ func GetDefaultSchema() AuthorizationSchema {
 		platformUserManagerPermissions,
 		platformOrganizationManagerPermissions,
 		platformAuditorPermissions,
+		platformWorkspaceManagerPermissions,
 		appStoreAdminPermissions,
 		dataManagerPermissions,
 		workspaceAdminPermissions,
@@ -422,6 +429,12 @@ func GetDefaultSchema() AuthorizationSchema {
 				"Platform auditors can audit the platform",
 				anyContext(RoleContextUser),
 				platformAuditorPermissions,
+			),
+			roleDefinition(
+				RolePlatformWorkspaceManager,
+				"Platform workspace managers can create workspaces",
+				anyContext(RoleContextUser),
+				platformWorkspaceManagerPermissions,
 			),
 			roleDefinition(
 				RoleAppStoreAdmin,

--- a/pkg/authorization/model/default_schema.go
+++ b/pkg/authorization/model/default_schema.go
@@ -435,7 +435,7 @@ func GetDefaultSchema() AuthorizationSchema {
 			roleDefinition(
 				RolePlatformWorkspaceManager,
 				"Platform workspace managers can create, update, and delete any workspace",
-				anyContext(RoleContextUser),
+				nil,
 				platformWorkspaceManagerPermissions,
 			),
 			roleDefinition(

--- a/pkg/authorization/model/default_schema.go
+++ b/pkg/authorization/model/default_schema.go
@@ -188,6 +188,8 @@ func GetDefaultSchema() AuthorizationSchema {
 		authenticatedPermissions,
 		[]PermissionName{
 			PermissionCreateWorkspace,
+			PermissionUpdateWorkspace,
+			PermissionDeleteWorkspace,
 		},
 	)
 
@@ -432,7 +434,7 @@ func GetDefaultSchema() AuthorizationSchema {
 			),
 			roleDefinition(
 				RolePlatformWorkspaceManager,
-				"Platform workspace managers can create workspaces",
+				"Platform workspace managers can create, update, and delete any workspace",
 				anyContext(RoleContextUser),
 				platformWorkspaceManagerPermissions,
 			),

--- a/pkg/authorization/model/role.go
+++ b/pkg/authorization/model/role.go
@@ -67,6 +67,7 @@ const (
 	RolePlateformUserManager        RoleName = "PlateformUserManager"
 	RolePlatformOrganizationManager RoleName = "PlatformOrganizationManager"
 	RolePlatformAuditor             RoleName = "PlatformAuditor"
+	RolePlatformWorkspaceManager    RoleName = "PlatformWorkspaceManager"
 	RoleAppStoreAdmin               RoleName = "AppStoreAdmin"
 	RoleDataManager                 RoleName = "DataManager"
 	RoleSuperAdmin                  RoleName = "SuperAdmin"
@@ -120,6 +121,7 @@ func GetAllRoles() []RoleName {
 		RolePlateformUserManager,
 		RolePlatformOrganizationManager,
 		RolePlatformAuditor,
+		RolePlatformWorkspaceManager,
 		RoleAppStoreAdmin,
 		RoleDataManager,
 		RoleSuperAdmin,

--- a/pkg/authorization/store/postgres/user-permission-storage_integration_test.go
+++ b/pkg/authorization/store/postgres/user-permission-storage_integration_test.go
@@ -25,7 +25,8 @@ func testRolesGrantingPermissions() map[authorization_model.PermissionName][]aut
 			authorization_model.RoleWorkspaceGuest,
 		},
 		authorization_model.PermissionCreateWorkspace: {
-			authorization_model.RoleAuthenticated,
+			authorization_model.RolePlatformWorkspaceManager,
+			authorization_model.RoleSuperAdmin,
 		},
 		authorization_model.PermissionApproveRequest: {
 			authorization_model.RoleWorkspaceDataManager,
@@ -154,9 +155,9 @@ func TestUserPermissionStorage_FindUsersWithPermission_NoContext(t *testing.T) {
 
 	fixtures := setupTestFixtures(t, db)
 
-	assignRole(t, db, &fixtures, fixtures.userIDs["alice"], fixtures.roleIDs["Authenticated"])
-	assignRole(t, db, &fixtures, fixtures.userIDs["bob"], fixtures.roleIDs["Authenticated"])
-	assignRole(t, db, &fixtures, fixtures.userIDs["inactive_user"], fixtures.roleIDs["Authenticated"])
+	assignRole(t, db, &fixtures, fixtures.userIDs["alice"], fixtures.roleIDs["PlatformWorkspaceManager"])
+	assignRole(t, db, &fixtures, fixtures.userIDs["bob"], fixtures.roleIDs["PlatformWorkspaceManager"])
+	assignRole(t, db, &fixtures, fixtures.userIDs["inactive_user"], fixtures.roleIDs["PlatformWorkspaceManager"])
 
 	store := NewUserPermissionStorage(db)
 
@@ -333,8 +334,8 @@ func TestUserPermissionStorage_FindUsersWithPermission_MultiTenant(t *testing.T)
 	`, testUserOtherID, testTenant2ID)
 	require.NoError(t, err)
 
-	assignRole(t, db, &fixtures, fixtures.userIDs["alice"], fixtures.roleIDs["Authenticated"])
-	assignRole(t, db, &fixtures, testUserOtherID, fixtures.roleIDs["Authenticated"])
+	assignRole(t, db, &fixtures, fixtures.userIDs["alice"], fixtures.roleIDs["PlatformWorkspaceManager"])
+	assignRole(t, db, &fixtures, testUserOtherID, fixtures.roleIDs["PlatformWorkspaceManager"])
 
 	store := NewUserPermissionStorage(db)
 

--- a/tests/acceptance/workspace/workspace_test.go
+++ b/tests/acceptance/workspace/workspace_test.go
@@ -220,6 +220,54 @@ var _ = Describe("workspace service", func() {
 				})
 			})
 		})
+
+		Given("a valid jwt-token with PlatformWorkspaceManager role, on a workspace it does not administer", func() {
+			When("PUT /api/rest/v1/workspaces/{id} changes visibility to public", func() {
+
+				Then("workspace visibility is updated to public", func() {
+					visPublic := workspace_models.ChorusWorkspaceVisibilityWORKSPACEVISIBILITYPUBLIC
+					req := workspace_svc.NewWorkspaceServiceUpdateWorkspaceParams().WithBody(
+						&workspace_models.ChorusWorkspace{ID: "80001", Name: "Private WS", ShortName: "private-ws", Visibility: &visPublic},
+					)
+					c := helpers.WorkspaceServiceHTTPClient()
+					resp, err := c.WorkspaceService.WorkspaceServiceUpdateWorkspace(req, platformWorkspaceManagerAuth(90001))
+
+					ExpectAPIErr(err).Should(BeNil())
+					ws := resp.Payload.Result.Workspace
+					Expect(*ws.Visibility).Should(Equal(workspace_models.ChorusWorkspaceVisibilityWORKSPACEVISIBILITYPUBLIC))
+				})
+			})
+		})
+	})
+
+	Describe("delete workspace", func() {
+
+		Given("a valid jwt-token with only the Authenticated role", func() {
+			When("DELETE /api/rest/v1/workspaces/{id} is called", func() {
+
+				Then("a permission error is returned", func() {
+					req := workspace_svc.NewWorkspaceServiceDeleteWorkspaceParams().WithID("80002")
+					c := helpers.WorkspaceServiceHTTPClient()
+					_, err := c.WorkspaceService.WorkspaceServiceDeleteWorkspace(req, authenticatedAuth(90001))
+
+					ExpectAPIErr(err).ShouldNot(BeNil())
+					Expect(err.Error()).Should(ContainSubstring(fmt.Sprintf("%v", http.StatusForbidden)))
+				})
+			})
+		})
+
+		Given("a valid jwt-token with PlatformWorkspaceManager role, on a workspace it does not administer", func() {
+			When("DELETE /api/rest/v1/workspaces/{id} is called", func() {
+
+				Then("the workspace is deleted", func() {
+					req := workspace_svc.NewWorkspaceServiceDeleteWorkspaceParams().WithID("80002")
+					c := helpers.WorkspaceServiceHTTPClient()
+					_, err := c.WorkspaceService.WorkspaceServiceDeleteWorkspace(req, platformWorkspaceManagerAuth(90001))
+
+					ExpectAPIErr(err).Should(BeNil())
+				})
+			})
+		})
 	})
 })
 

--- a/tests/acceptance/workspace/workspace_test.go
+++ b/tests/acceptance/workspace/workspace_test.go
@@ -32,6 +32,10 @@ func authenticatedAuth(userID uint64) func(*runtime.ClientOperation) {
 	return getAuthAsClientOpts(helpers.CreateJWTToken(userID, 88888, authorization.RoleAuthenticated.String(), map[string]string{"user": fmt.Sprintf("%d", userID)}))
 }
 
+func platformWorkspaceManagerAuth(userID uint64) func(*runtime.ClientOperation) {
+	return getAuthAsClientOpts(helpers.CreateJWTToken(userID, 88888, authorization.RolePlatformWorkspaceManager.String(), map[string]string{}))
+}
+
 var _ = Describe("workspace service", func() {
 
 	BeforeEach(func() {
@@ -143,7 +147,23 @@ var _ = Describe("workspace service", func() {
 			})
 		})
 
-		Given("a valid jwt-token with Authenticated role", func() {
+		Given("a valid jwt-token with only the Authenticated role", func() {
+			When("POST /api/rest/v1/workspaces is called", func() {
+
+				Then("a permission error is returned", func() {
+					req := workspace_svc.NewWorkspaceServiceCreateWorkspaceParams().WithBody(
+						&workspace_models.ChorusWorkspace{Name: "Default WS", ShortName: "default-ws"},
+					)
+					c := helpers.WorkspaceServiceHTTPClient()
+					_, err := c.WorkspaceService.WorkspaceServiceCreateWorkspace(req, authenticatedAuth(90000))
+
+					ExpectAPIErr(err).ShouldNot(BeNil())
+					Expect(err.Error()).Should(ContainSubstring(fmt.Sprintf("%v", http.StatusForbidden)))
+				})
+			})
+		})
+
+		Given("a valid jwt-token with PlatformWorkspaceManager role", func() {
 			When("POST /api/rest/v1/workspaces is called without explicit visibility", func() {
 
 				Then("workspace is created with correct defaults (requester as owner, status is active, private visibility)", func() {
@@ -151,7 +171,7 @@ var _ = Describe("workspace service", func() {
 						&workspace_models.ChorusWorkspace{Name: "Default WS", ShortName: "default-ws", Description: "No explicit visibility"},
 					)
 					c := helpers.WorkspaceServiceHTTPClient()
-					resp, err := c.WorkspaceService.WorkspaceServiceCreateWorkspace(req, authenticatedAuth(90000))
+					resp, err := c.WorkspaceService.WorkspaceServiceCreateWorkspace(req, platformWorkspaceManagerAuth(90000))
 
 					ExpectAPIErr(err).Should(BeNil())
 					ws := resp.Payload.Result.Workspace
@@ -170,7 +190,7 @@ var _ = Describe("workspace service", func() {
 						&workspace_models.ChorusWorkspace{Name: "Public WS 2", ShortName: "public-ws-2", Visibility: &visPublic},
 					)
 					c := helpers.WorkspaceServiceHTTPClient()
-					resp, err := c.WorkspaceService.WorkspaceServiceCreateWorkspace(req, authenticatedAuth(90000))
+					resp, err := c.WorkspaceService.WorkspaceServiceCreateWorkspace(req, platformWorkspaceManagerAuth(90000))
 
 					ExpectAPIErr(err).Should(BeNil())
 					ws := resp.Payload.Result.Workspace


### PR DESCRIPTION
## Restrict workspace create/update/delete to a new PlatformWorkspaceManager role

The team decided that users with the base `Authenticated` role should no longer be able to create, update, or delete workspaces. Those permissions were only ever granted through the shared `authenticatedPermissions` list, so removing them there cascades to every role that inherited it — a new `PlatformWorkspaceManager` role now owns them going forward, and `SuperAdmin` keeps them explicitly.

### Changes

- `pkg/authorization/model/default_schema.go` — removed `PermissionCreateWorkspace`, `PermissionUpdateWorkspace`, and `PermissionDeleteWorkspace` from `authenticatedPermissions`; added a `PlatformWorkspaceManager` role (authenticated base + those three permissions), matching the shape of the other single-purpose `platform*Manager` roles; added it to `superAdmin`'s composition
- `pkg/authorization/model/role.go` — new `RolePlatformWorkspaceManager` constant, registered in `GetAllRoles()`
- `internal/migration/chorus/postgres/00047_authorization_platformworkspacemanager.sql` — seeds the new role row, same pattern as every previous new role
- `tests/acceptance/workspace/workspace_test.go`:
  - `Authenticated`-role create-workspace case now expects `403`; added a matching happy-path case under `PlatformWorkspaceManager`
  - Added a `PlatformWorkspaceManager` update-workspace case against a workspace it doesn't administer
  - Added a new "delete workspace" suite (previously zero acceptance coverage for delete): `Authenticated` gets `403`, `PlatformWorkspaceManager` succeeds
- `pkg/authorization/store/postgres/user-permission-storage_integration_test.go` — fixture role assignments and the permission→role mapping updated to match the new schema

### Effects

- Users with only `Authenticated` get `403 Forbidden` on create/update/delete workspace endpoints
- `SuperAdmin` and the new `PlatformWorkspaceManager` role can still create, update, and delete workspaces
- `PlatformWorkspaceManager`'s grant is platform-wide, not scoped per-workspace: its JWT role context never carries a workspace dimension, so update/delete apply to *any* workspace, not just ones the holder administers — confirmed via the authorization matching logic and an end-to-end acceptance run
- No existing user is auto-granted `PlatformWorkspaceManager` — needs explicit assignment to whoever should retain these abilities
- No manual DB step beyond deploying — `NewAuthorizationService` reconciles each system role's permissions from this schema on every startup; the migration only seeds the new role's row

### Verification

- `go build ./...` and the full unit test suite pass
- Full integration test suite passes against a real embedded Postgres (`go test --tags=integration ./pkg/authorization/...`)
- `make test-acceptance-coverage SUITE=workspace` — ran the actual backend end-to-end; all cases pass, including `PlatformWorkspaceManager` successfully updating/deleting a workspace it doesn't administer

