### PR TITLE
Fix/add get ws to platformworkspacemanager

### DIFF
--- a/internal/migration/chorus/postgres/00048_authorization_platform_role_renames.sql
+++ b/internal/migration/chorus/postgres/00048_authorization_platform_role_renames.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+
+-- +migrate StatementBegin
+UPDATE role_definitions SET name = 'PlatformUserManager' WHERE name = 'PlateformUserManager';
+-- +migrate StatementEnd
+
+-- +migrate StatementBegin
+UPDATE role_definitions SET name = 'PlatformDataManager' WHERE name = 'DataManager';
+-- +migrate StatementEnd

--- a/pkg/authorization/model/default_schema.go
+++ b/pkg/authorization/model/default_schema.go
@@ -435,7 +435,7 @@ func GetDefaultSchema() AuthorizationSchema {
 			),
 			roleDefinition(
 				RolePlatformWorkspaceManager,
-				"Platform workspace managers can create, get, update, and delete any workspace",
+				"Platform workspace managers can manage any workspace",
 				anyContext(RoleContextWorkspace),
 				platformWorkspaceManagerPermissions,
 			),

--- a/pkg/authorization/model/default_schema.go
+++ b/pkg/authorization/model/default_schema.go
@@ -436,7 +436,7 @@ func GetDefaultSchema() AuthorizationSchema {
 			roleDefinition(
 				RolePlatformWorkspaceManager,
 				"Platform workspace managers can create, get, update, and delete any workspace",
-				nil,
+				anyContext(RoleContextWorkspace),
 				platformWorkspaceManagerPermissions,
 			),
 			roleDefinition(

--- a/pkg/authorization/model/default_schema.go
+++ b/pkg/authorization/model/default_schema.go
@@ -188,6 +188,7 @@ func GetDefaultSchema() AuthorizationSchema {
 		authenticatedPermissions,
 		[]PermissionName{
 			PermissionCreateWorkspace,
+			PermissionGetWorkspace,
 			PermissionUpdateWorkspace,
 			PermissionDeleteWorkspace,
 		},
@@ -415,7 +416,7 @@ func GetDefaultSchema() AuthorizationSchema {
 				platformSettingsManagerPermissions,
 			),
 			roleDefinition(
-				RolePlateformUserManager,
+				RolePlatformUserManager,
 				"Platform user managers can administer platform users and their roles",
 				anyContext(RoleContextUser),
 				platformUserManagerPermissions,
@@ -434,7 +435,7 @@ func GetDefaultSchema() AuthorizationSchema {
 			),
 			roleDefinition(
 				RolePlatformWorkspaceManager,
-				"Platform workspace managers can create, update, and delete any workspace",
+				"Platform workspace managers can create, get, update, and delete any workspace",
 				nil,
 				platformWorkspaceManagerPermissions,
 			),
@@ -445,7 +446,7 @@ func GetDefaultSchema() AuthorizationSchema {
 				appStoreAdminPermissions,
 			),
 			roleDefinition(
-				RoleDataManager,
+				RolePlatformDataManager,
 				"Data managers can manage workspace data across workspaces",
 				anyContext(RoleContextWorkspace),
 				dataManagerPermissions,

--- a/pkg/authorization/model/role.go
+++ b/pkg/authorization/model/role.go
@@ -64,12 +64,12 @@ const (
 	RoleWorkbenchAdmin              RoleName = "WorkbenchAdmin"
 	RoleHealthchecker               RoleName = "Healthchecker"
 	RolePlatformSettingsManager     RoleName = "PlatformSettingsManager"
-	RolePlateformUserManager        RoleName = "PlateformUserManager"
+	RolePlatformUserManager         RoleName = "PlatformUserManager"
 	RolePlatformOrganizationManager RoleName = "PlatformOrganizationManager"
 	RolePlatformAuditor             RoleName = "PlatformAuditor"
 	RolePlatformWorkspaceManager    RoleName = "PlatformWorkspaceManager"
 	RoleAppStoreAdmin               RoleName = "AppStoreAdmin"
-	RoleDataManager                 RoleName = "DataManager"
+	RolePlatformDataManager         RoleName = "PlatformDataManager"
 	RoleSuperAdmin                  RoleName = "SuperAdmin"
 )
 
@@ -118,12 +118,12 @@ func GetAllRoles() []RoleName {
 		RoleWorkbenchAdmin,
 		RoleHealthchecker,
 		RolePlatformSettingsManager,
-		RolePlateformUserManager,
+		RolePlatformUserManager,
 		RolePlatformOrganizationManager,
 		RolePlatformAuditor,
 		RolePlatformWorkspaceManager,
 		RoleAppStoreAdmin,
-		RoleDataManager,
+		RolePlatformDataManager,
 		RoleSuperAdmin,
 	}
 }

--- a/tests/acceptance/user/user_test.go
+++ b/tests/acceptance/user/user_test.go
@@ -679,7 +679,7 @@ var _ = Describe("user service", func() {
 				When("the route POST '/api/rest/v1/users' is called", func() {
 
 					Then("a validation error should be raised", func() {
-						auth := getAuthAsClientOpts(helpers.CreateJWTToken(90000, 88888, string(authorization.RolePlateformUserManager), map[string]string{}))
+						auth := getAuthAsClientOpts(helpers.CreateJWTToken(90000, 88888, string(authorization.RolePlatformUserManager), map[string]string{}))
 
 						req := user.NewUserServiceCreateUserParams().WithBody(
 							&models.ChorusUser{
@@ -707,7 +707,7 @@ var _ = Describe("user service", func() {
 
 					Then("a user should be returned", func() {
 						setupBaseTables()
-						auth := getAuthAsClientOpts(helpers.CreateJWTToken(90000, 88888, string(authorization.RolePlateformUserManager), map[string]string{}))
+						auth := getAuthAsClientOpts(helpers.CreateJWTToken(90000, 88888, string(authorization.RolePlatformUserManager), map[string]string{}))
 
 						req := user.NewUserServiceCreateUserParams().WithBody(
 							&models.ChorusUser{

--- a/tests/acceptance/workspace/workspace_test.go
+++ b/tests/acceptance/workspace/workspace_test.go
@@ -33,7 +33,7 @@ func authenticatedAuth(userID uint64) func(*runtime.ClientOperation) {
 }
 
 func platformWorkspaceManagerAuth(userID uint64) func(*runtime.ClientOperation) {
-	return getAuthAsClientOpts(helpers.CreateJWTToken(userID, 88888, authorization.RolePlatformWorkspaceManager.String(), map[string]string{}))
+	return getAuthAsClientOpts(helpers.CreateJWTToken(userID, 88888, authorization.RolePlatformWorkspaceManager.String(), map[string]string{"workspace": "*"}))
 }
 
 var _ = Describe("workspace service", func() {
@@ -104,6 +104,24 @@ var _ = Describe("workspace service", func() {
 					ws := resp.Payload.Result.Workspace
 					Expect(ws.Name).Should(Equal("Private WS"))
 					Expect(ws.ShortName).Should(Equal("private-ws"))
+				})
+			})
+		})
+	})
+
+	Describe("list workspaces", func() {
+
+		Given("a valid jwt-token with PlatformWorkspaceManager role", func() {
+			When("GET /api/rest/v1/workspaces is called with no filter", func() {
+
+				Then("every workspace is returned", func() {
+					req := workspace_svc.NewWorkspaceServiceListWorkspacesParams()
+					c := helpers.WorkspaceServiceHTTPClient()
+					resp, err := c.WorkspaceService.WorkspaceServiceListWorkspaces(req, platformWorkspaceManagerAuth(90001))
+
+					ExpectAPIErr(err).Should(BeNil())
+					workspaces := resp.Payload.Result.Workspaces
+					Expect(workspaces).Should(HaveLen(2))
 				})
 			})
 		})

--- a/tests/acceptance/workspace/workspace_test.go
+++ b/tests/acceptance/workspace/workspace_test.go
@@ -91,6 +91,22 @@ var _ = Describe("workspace service", func() {
 				})
 			})
 		})
+
+		Given("a valid jwt-token with PlatformWorkspaceManager role, on a workspace it does not administer", func() {
+			When("GET /api/rest/v1/workspaces/{id} is called", func() {
+
+				Then("the workspace is returned with correct fields", func() {
+					req := workspace_svc.NewWorkspaceServiceGetWorkspaceParams().WithID("80001")
+					c := helpers.WorkspaceServiceHTTPClient()
+					resp, err := c.WorkspaceService.WorkspaceServiceGetWorkspace(req, platformWorkspaceManagerAuth(90001))
+
+					ExpectAPIErr(err).Should(BeNil())
+					ws := resp.Payload.Result.Workspace
+					Expect(ws.Name).Should(Equal("Private WS"))
+					Expect(ws.ShortName).Should(Equal("private-ws"))
+				})
+			})
+		})
 	})
 
 	Describe("list public workspaces", func() {


### PR DESCRIPTION
## Fix PlatformWorkspaceManager's workspace-listing gap, and rename two roles for consistency

`PlatformWorkspaceManager` could `Get`/`Update`/`Delete` any individual workspace by ID, but `ListWorkspaces` silently returned nothing for it — its authorization context carried no `workspace` value, and the list endpoint only treats an explicit `"*"` as "show everything" (an absent dimension just gets skipped). Also renames two roles for consistency: a longstanding typo (`PlateformUserManager`) and `DataManager` → `PlatformDataManager` to match the rest of the `Platform*Manager` family.

### Changes

- `pkg/authorization/model/default_schema.go`
  - Added `PermissionGetWorkspace` to `PlatformWorkspaceManager`'s permission set
  - Changed its role context from `nil` to `anyContext(RoleContextWorkspace)` — makes the role internally consistent with its own permissions' context requirements (matches `PlatformDataManager`'s existing pattern); accepted side effect: this also makes it assignable via the per-workspace role-management API, to be addressed consistently across all roles separately
  - Renamed role definitions for `RolePlatformUserManager` and `RolePlatformDataManager`
- `pkg/authorization/model/role.go` — same two renames, including the underlying string values, plus their `GetAllRoles()` entries
- `internal/migration/chorus/postgres/00048_authorization_platform_role_renames.sql` — renames both existing DB rows in place (`UPDATE ... WHERE name = ...`), preserving role IDs and every existing `user_role` assignment
- `tests/acceptance/workspace/workspace_test.go`
  - `platformWorkspaceManagerAuth()` now carries `{"workspace": "*"}` instead of an empty context — this is the actual fix; the role-context change above doesn't by itself inject this value anywhere
  - Added a `GetWorkspace` case for a workspace the role doesn't administer, and a new "list workspaces" suite (no prior coverage existed for the non-public list endpoint) proving all workspaces are returned
- `tests/acceptance/user/user_test.go` — updated to the renamed `RolePlatformUserManager` constant

### Effects

- `PlatformWorkspaceManager` now sees every workspace via `ListWorkspaces`, not just ones it can address by ID directly
- Any currently-logged-in user holding `PlateformUserManager` or `DataManager` needs to re-authenticate to pick up the renamed role in their JWT — brief, self-correcting, no data loss (the DB rows are renamed in place, not recreated)

### Verification

- `go build ./...` (incl. `acceptance` tag), full unit suite, full integration suite (real Postgres, migration applies cleanly) all pass
- Full acceptance suite (all 8 packages) passes end-to-end against a real running backend
