### PR TITLE
fix: return validation error from UpdateApp

### DIFF
--- a/pkg/app/service/middleware/validation.go
+++ b/pkg/app/service/middleware/validation.go
@@ -41,7 +41,7 @@ func (v validation) DeleteApp(ctx context.Context, tenantID, appID uint64) error
 
 func (v validation) UpdateApp(ctx context.Context, app *model.App) (*model.App, error) {
 	if err := v.validate.Struct(app); err != nil {
-		return v.next.UpdateApp(ctx, app)
+		return nil, err
 	}
 	return v.next.UpdateApp(ctx, app)
 }


### PR DESCRIPTION
## Reject invalid App updates instead of silently accepting them

The `UpdateApp` validation middleware computed the struct-validation error but then called the next handler in **both** branches, so the error was discarded and an invalid `App` update was never rejected — the validation was effectively dead code. This makes `UpdateApp` behave like the sibling `CreateApp` / `BulkCreateApps` handlers, which return the error.

This is a pre-existing bug (it predates and is independent of the web-service app work); it was noticed while auditing the app write path and is split out here so it can be reviewed on its own.

### Changes

- `pkg/app/service/middleware/validation.go` — `UpdateApp` returns the validator error when `validate.Struct(app)` fails, instead of falling through to `next.UpdateApp`.

### Effects

- Invalid `App` updates are now rejected with the validator error, matching `CreateApp`. Valid updates are unchanged.

### Verification

- `gofmt` clean, `go build ./...` and `go vet ./...` clean.
- `make test-unit` passes.
