### PR TITLE
fix(authz): update role expansion logic to fix implicit wildcard context

### DIFF
--- a/pkg/authorization/model/default_schema.go
+++ b/pkg/authorization/model/default_schema.go
@@ -258,7 +258,7 @@ func GetDefaultSchema() AuthorizationSchema {
 			permissionDefinition(PermissionCountUnreadNotifications, "Allow the user to count unread notifications", contexts(one(ContextUser))),
 			permissionDefinition(PermissionMarkNotificationAsRead, "Allow the user to mark a notification as read", contexts(one(ContextUser))),
 
-			permissionDefinition(PermissionListUsers, "Allow the user to list users", contexts(one(ContextUser))),
+			permissionDefinition(PermissionListUsers, "Allow the user to list users", nil),
 			permissionDefinition(PermissionSearchUsers, "Allow the user to search users", nil),
 			permissionDefinition(PermissionCreateUser, "Allow the user to create a user", nil),
 			permissionDefinition(PermissionUpdateUser, "Allow the user to update a user", contexts(one(ContextUser))),
@@ -277,7 +277,7 @@ func GetDefaultSchema() AuthorizationSchema {
 			permissionDefinition(PermissionAuditPlatform, "Allow the user to audit the platform", nil),
 			permissionDefinition(PermissionManageDynamicRoles, "Allow the user to create dynamic roles", nil),
 
-			permissionDefinition(PermissionListAppInstances, "Allow the user to list app instances", contexts(one(ContextWorkbench))),
+			permissionDefinition(PermissionListAppInstances, "Allow the user to list app instances", nil),
 			permissionDefinition(PermissionCreateAppInstance, "Allow the user to create an app instance", contexts(one(ContextWorkbench))),
 			permissionDefinition(PermissionUpdateAppInstance, "Allow the user to update an app instance", contexts(one(ContextWorkbench))),
 			permissionDefinition(PermissionGetAppInstance, "Allow the user to get an app instance", contexts(one(ContextWorkbench))),

--- a/pkg/authorization/service/policy.go
+++ b/pkg/authorization/service/policy.go
@@ -17,26 +17,27 @@ import (
 func expandUserPermissions(
 	roles map[model.RoleName]*model.RoleDefinition,
 	permissions map[model.PermissionName]model.PermissionDefinition,
-	user []model.Role,
+	userRoles []model.Role,
 ) ([]model.Permission, error) {
 	expanded := make([]model.Permission, 0)
-	for _, role := range user {
-		definition, ok := roles[role.Name]
+
+	for _, role := range userRoles {
+		roleDefinition, ok := roles[role.Name]
 		if !ok {
 			return nil, fmt.Errorf("role %q not found in schema", role.Name)
 		}
-		for _, permissionName := range definition.Permissions {
-			permissionDefinition := permissions[permissionName]
-			permission := model.Permission{
-				Name:    permissionName,
-				Context: make(model.Context, len(permissionDefinition.RequiredContextDimensions)),
-			}
-			for _, dimension := range permissionDefinition.RequiredContextDimensions {
-				if actualValue, ok := role.Context[dimension]; ok {
-					permission.Context[dimension] = actualValue
+
+		for _, permissionName := range roleDefinition.Permissions {
+			required := permissions[permissionName].RequiredContextDimensions
+			context := make(model.Context, len(required))
+			for _, dimension := range required {
+				if value, ok := role.Context[dimension]; ok {
+					context[dimension] = value
 				}
 			}
-			expanded = append(expanded, permission)
+			if len(context) == len(required) {
+				expanded = append(expanded, model.Permission{Name: permissionName, Context: context})
+			}
 		}
 	}
 	return expanded, nil

--- a/pkg/authorization/service/policy_test.go
+++ b/pkg/authorization/service/policy_test.go
@@ -1,0 +1,110 @@
+//go:build unit
+
+package service
+
+import (
+	"testing"
+
+	"github.com/CHORUS-TRE/chorus-backend/pkg/authorization/model"
+)
+
+// TestExpandDropsUnboundRequiredContext is the regression test for the
+// cross-workspace escalation: a role that binds only `workspace` but grants a
+// permission requiring `workbench` must never match a workbench check.
+func TestExpandDropsUnboundRequiredContext(t *testing.T) {
+	schema := &model.AuthorizationSchema{
+		Permissions: []model.PermissionDefinition{
+			{
+				Name:                      model.PermissionGetWorkbench,
+				RequiredContextDimensions: []model.ContextDimension{model.ContextWorkbench},
+			},
+		},
+		Roles: []*model.RoleDefinition{
+			// WorkspaceAdmin shape: binds workspace, grants a workbench-scoped permission.
+			{Name: model.RoleWorkspaceAdmin, Permissions: []model.PermissionName{model.PermissionGetWorkbench}},
+			// WorkbenchAdmin shape: binds workbench, grants the same permission.
+			{Name: model.RoleWorkbenchAdmin, Permissions: []model.PermissionName{model.PermissionGetWorkbench}},
+		},
+	}
+
+	svc, err := newTestAuthorizationService(schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name  string
+		roles []model.Role
+		check model.Permission
+		want  bool
+	}{
+		{
+			name:  "WorkspaceAdmin (binds workspace, not workbench) denied on any workbench — the bug",
+			roles: []model.Role{{Name: model.RoleWorkspaceAdmin, Context: model.Context{model.ContextWorkspace: "4"}}},
+			check: model.NewPermission(model.PermissionGetWorkbench, model.WithWorkbench(7)),
+			want:  false,
+		},
+		{
+			name:  "WorkbenchAdmin bound to workbench 7 allowed on workbench 7",
+			roles: []model.Role{{Name: model.RoleWorkbenchAdmin, Context: model.Context{model.ContextWorkbench: "7"}}},
+			check: model.NewPermission(model.PermissionGetWorkbench, model.WithWorkbench(7)),
+			want:  true,
+		},
+		{
+			name:  "WorkbenchAdmin bound to workbench 9 denied on workbench 7",
+			roles: []model.Role{{Name: model.RoleWorkbenchAdmin, Context: model.Context{model.ContextWorkbench: "9"}}},
+			check: model.NewPermission(model.PermissionGetWorkbench, model.WithWorkbench(7)),
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := svc.IsUserAllowed(tt.roles, tt.check)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("IsUserAllowed = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExpandKeepsZeroContextAndWildcard covers the non-regression cases: a
+// context-free permission still matches, and a wildcard binding matches any value.
+func TestExpandKeepsZeroContextAndWildcard(t *testing.T) {
+	schema := &model.AuthorizationSchema{
+		Permissions: []model.PermissionDefinition{
+			{Name: model.PermissionCreateWorkspace}, // no required context
+			{
+				Name:                      model.PermissionGetWorkbench,
+				RequiredContextDimensions: []model.ContextDimension{model.ContextWorkbench},
+			},
+		},
+		Roles: []*model.RoleDefinition{
+			{Name: model.RoleAuthenticated, Permissions: []model.PermissionName{model.PermissionCreateWorkspace}},
+			{Name: model.RoleSuperAdmin, Permissions: []model.PermissionName{model.PermissionGetWorkbench}},
+		},
+	}
+	svc, err := newTestAuthorizationService(schema)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// context-free permission matches with no context supplied.
+	if allowed, err := svc.IsUserAllowed(
+		[]model.Role{{Name: model.RoleAuthenticated}},
+		model.NewPermission(model.PermissionCreateWorkspace),
+	); err != nil || !allowed {
+		t.Fatalf("context-free permission should be allowed: allowed=%v err=%v", allowed, err)
+	}
+
+	// wildcard workbench binding matches any workbench.
+	if allowed, err := svc.IsUserAllowed(
+		[]model.Role{{Name: model.RoleSuperAdmin, Context: model.Context{model.ContextWorkbench: model.Wildcard}}},
+		model.NewPermission(model.PermissionGetWorkbench, model.WithWorkbench(999)),
+	); err != nil || !allowed {
+		t.Fatalf("wildcard workbench should match any workbench: allowed=%v err=%v", allowed, err)
+	}
+}


### PR DESCRIPTION
This pull request addresses a critical bug in the authorization logic where users could be incorrectly granted permissions across workspaces or workbenches due to unbound context dimensions. The main changes ensure that permissions are only granted if all required context dimensions are properly bound, preventing privilege escalation. Additionally, regression tests are added to verify the correct behavior and prevent similar issues in the future.

**Authorization logic fixes:**

* Updated `expandUserPermissions` in `pkg/authorization/service/policy.go` to only grant permissions if all required context dimensions are present in the role's context, preventing unintentional cross-context permission grants.
* Modified permission definitions in `pkg/authorization/model/default_schema.go` to remove unnecessary context requirements from `PermissionListUsers` and `PermissionListAppInstances`, aligning with the new logic. [[1]](diffhunk://#diff-865caa728c1f500c35355ba8653d2f6fa4dcbb8ae6ee7f86b4cc4e49614da38eL261-R261) [[2]](diffhunk://#diff-865caa728c1f500c35355ba8653d2f6fa4dcbb8ae6ee7f86b4cc4e49614da38eL280-R280)

**Testing and regression coverage:**

* Added unit tests in `pkg/authorization/service/policy_test.go` to verify that permissions requiring unbound context dimensions are not granted, and to ensure correct handling of context-free and wildcard-bound permissions.