### PR TITLE
fix(workbench): add specific function to update workbench statuses from watcher

### DIFF
--- a/pkg/workbench/service/workbench-service.go
+++ b/pkg/workbench/service/workbench-service.go
@@ -84,6 +84,7 @@ type WorkbenchStore interface {
 	SaveBatchProxyHit(ctx context.Context, proxyHitCountMap map[uint64]uint64, proxyHitDateMap map[uint64]time.Time) error
 	CreateWorkbench(ctx context.Context, tenantID uint64, workbench *model.Workbench) (*model.Workbench, error)
 	UpdateWorkbench(ctx context.Context, tenantID uint64, workbench *model.Workbench) (*model.Workbench, error)
+	UpdateWorkbenchStatus(ctx context.Context, tenantID uint64, workbench *model.Workbench) (*model.Workbench, error)
 	DeleteWorkbench(ctx context.Context, tenantID uint64, workbenchID uint64) error
 	DeleteWorkbenchesInWorkspace(ctx context.Context, tenantID uint64, workspaceID uint64) error
 	DeleteIdleWorkbenches(ctx context.Context, idleTimeout time.Duration) ([]*model.Workbench, error)
@@ -223,11 +224,11 @@ func (s *WorkbenchService) SetClientWatchers() {
 			workbench.Status = model.WorkbenchDeleted
 		}
 
-		// Update workbench in DB
-		logger.TechLog.Debug(ctx, "updating workbench", zap.String("namespace", k8sWorkbench.Namespace), zap.String("workbenchName", k8sWorkbench.Name), zap.Any("workbench", workbench))
-		_, err = s.store.UpdateWorkbench(ctx, k8sWorkbench.TenantID, workbench)
+		// Update workbench statuses in DB
+		logger.TechLog.Debug(ctx, "updating workbench status", zap.String("namespace", k8sWorkbench.Namespace), zap.String("workbenchName", k8sWorkbench.Name), zap.Any("workbench", workbench))
+		_, err = s.store.UpdateWorkbenchStatus(ctx, k8sWorkbench.TenantID, workbench)
 		if err != nil {
-			logger.TechLog.Error(ctx, "unable to update workbench", zap.String("namespace", k8sWorkbench.Namespace), zap.String("workbenchName", k8sWorkbench.Name), zap.Any("workbench", workbench), zap.Error(err))
+			logger.TechLog.Error(ctx, "unable to update workbench status", zap.String("namespace", k8sWorkbench.Namespace), zap.String("workbenchName", k8sWorkbench.Name), zap.Any("workbench", workbench), zap.Error(err))
 			return err
 		}
 

--- a/pkg/workbench/store/middleware/logging.go
+++ b/pkg/workbench/store/middleware/logging.go
@@ -209,6 +209,26 @@ func (c workbenchStorageLogging) UpdateWorkbench(ctx context.Context, tenantID u
 	return updatedWorkbench, nil
 }
 
+func (c workbenchStorageLogging) UpdateWorkbenchStatus(ctx context.Context, tenantID uint64, workbench *model.Workbench) (*model.Workbench, error) {
+	c.logger.Debug(ctx, "request started")
+	now := time.Now()
+
+	updatedWorkbench, err := c.next.UpdateWorkbenchStatus(ctx, tenantID, workbench)
+	if err != nil {
+		c.logger.Error(ctx, "request completed",
+			logger.WithWorkbenchIDField(workbench.ID),
+			zap.Error(err),
+			zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
+		)
+		return nil, err
+	}
+	c.logger.Debug(ctx, "request completed",
+		logger.WithWorkbenchIDField(updatedWorkbench.ID),
+		zap.Float64(logger.LoggerKeyElapsedMs, float64(time.Since(now).Nanoseconds())/1000000.0),
+	)
+	return updatedWorkbench, nil
+}
+
 func (c workbenchStorageLogging) CreateWorkbench(ctx context.Context, tenantID uint64, workbench *model.Workbench) (*model.Workbench, error) {
 	c.logger.Debug(ctx, "request started")
 

--- a/pkg/workbench/store/postgres/workbench-storage.go
+++ b/pkg/workbench/store/postgres/workbench-storage.go
@@ -224,14 +224,31 @@ func (s *WorkbenchStorage) CreateWorkbench(ctx context.Context, tenantID uint64,
 func (s *WorkbenchStorage) UpdateWorkbench(ctx context.Context, tenantID uint64, workbench *model.Workbench) (*model.Workbench, error) {
 	const workbenchUpdateQuery = `
 		UPDATE workbenches
-		SET name = $3, shortname = $4, description = $5, status = $6, serverpodstatus = $7, serverpodmessage = $8, k8sstatus = $9, updatedat = NOW()
+		SET name = $3, shortname = $4, description = $5, updatedat = NOW()
 		WHERE tenantid = $1 AND id = $2
 		RETURNING id, tenantid, userid, workspaceid, name, shortname, description, status, serverpodstatus, serverpodmessage, k8sstatus, initialresolutionwidth, initialresolutionheight, createdat, updatedat;
 	`
 
 	// Update workbench
 	var updatedWorkbench model.Workbench
-	err := s.db.GetContext(ctx, &updatedWorkbench, workbenchUpdateQuery, tenantID, workbench.ID, workbench.Name, workbench.ShortName, workbench.Description, workbench.Status, workbench.ServerPodStatus, workbench.ServerPodMessage, workbench.K8sStatus)
+	err := s.db.GetContext(ctx, &updatedWorkbench, workbenchUpdateQuery, tenantID, workbench.ID, workbench.Name, workbench.ShortName, workbench.Description)
+	if err != nil {
+		return nil, err
+	}
+
+	return &updatedWorkbench, nil
+}
+
+func (s *WorkbenchStorage) UpdateWorkbenchStatus(ctx context.Context, tenantID uint64, workbench *model.Workbench) (*model.Workbench, error) {
+	const workbenchStatusUpdateQuery = `
+		UPDATE workbenches
+		SET status = $3, serverpodstatus = $4, serverpodmessage = $5, k8sstatus = $6, updatedat = NOW()
+		WHERE tenantid = $1 AND id = $2
+		RETURNING id, tenantid, userid, workspaceid, name, shortname, description, status, serverpodstatus, serverpodmessage, k8sstatus, initialresolutionwidth, initialresolutionheight, createdat, updatedat;
+	`
+
+	var updatedWorkbench model.Workbench
+	err := s.db.GetContext(ctx, &updatedWorkbench, workbenchStatusUpdateQuery, tenantID, workbench.ID, workbench.Status, workbench.ServerPodStatus, workbench.ServerPodMessage, workbench.K8sStatus)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This pull request refactors how workbench status updates are handled in the service and storage layers. The main change is splitting the update logic into two separate methods: one for general workbench updates and one specifically for updating workbench statuses. This separation clarifies intent and can help prevent accidental overwrites of unrelated fields.

**API and Interface Changes**
- Added a new method `UpdateWorkbenchStatus` to the `WorkbenchStore` interface to handle updates to workbench status fields separately from other workbench fields.

**Service Layer Updates**
- Updated the `SetClientWatchers` method in `workbench-service.go` to use the new `UpdateWorkbenchStatus` method instead of the generic `UpdateWorkbench` when updating status-related fields.

**Logging Middleware**
- Implemented logging for the new `UpdateWorkbenchStatus` method in the `workbenchStorageLogging` middleware to ensure request tracing and error logging are consistent with other storage operations.

**Storage Layer (Postgres)**
- Refactored the `UpdateWorkbench` method to only update non-status fields (`name`, `shortname`, `description`), and added a new `UpdateWorkbenchStatus` method that only updates status-related fields (`status`, `serverpodstatus`, `serverpodmessage`, `k8sstatus`).

These changes improve maintainability by clearly separating status updates from other workbench updates, reducing the chance of unintended data modifications.