### PR TITLE
Feat/improve headers

### DIFF
--- a/internal/cmd/provider/config.go
+++ b/internal/cmd/provider/config.go
@@ -126,6 +126,8 @@ func formatValidationError(cfg config.Config, fe val.FieldError) string {
 		return fmt.Sprintf("FAIL '%s' must contain at least %s entry/entries", path, fe.Param())
 	case "required_openid":
 		return fmt.Sprintf("FAIL '%s' is missing (required for openid-type authentication modes)", path)
+	case "wildcard_with_allowlist":
+		return fmt.Sprintf("FAIL '%s' must be false when 'access_control_allow_origins' is non-empty", path)
 	default:
 		return fmt.Sprintf("FAIL '%s' failed '%s' validation", path, fe.Tag())
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,17 +26,12 @@ type (
 		} `yaml:"grpc"`
 
 		HTTP struct {
-			Host           string `yaml:"host" validate:"required"`
-			Port           string `yaml:"port" validate:"required"`
-			HeaderClientIP string `yaml:"header_client_ip"`
-			Headers        struct {
-				AccessControlAllowOrigins        []string `yaml:"access_control_allow_origins"`
-				AccessControlAllowOriginWildcard bool     `yaml:"access_control_allow_origin_wildcard"`
-				AccessControlMaxAge              string   `yaml:"access_control_max_age" validate:"required"`
-				CookieDomain                     string   `yaml:"cookie_domain" validate:"required"`
-			} `yaml:"headers"`
-			MaxCallRecvMsgSize int `yaml:"max_call_recv_msg_size" validate:"required"`
-			MaxCallSendMsgSize int `yaml:"max_call_send_msg_size" validate:"required"`
+			Host               string      `yaml:"host" validate:"required"`
+			Port               string      `yaml:"port" validate:"required"`
+			HeaderClientIP     string      `yaml:"header_client_ip"`
+			Headers            HTTPHeaders `yaml:"headers"`
+			MaxCallRecvMsgSize int         `yaml:"max_call_recv_msg_size" validate:"required"`
+			MaxCallSendMsgSize int         `yaml:"max_call_send_msg_size" validate:"required"`
 		} `yaml:"http"`
 
 		JWT struct {
@@ -67,6 +62,14 @@ type (
 				Password Sensitive `yaml:"password" validate:"required_if=Enabled true"`
 			} `yaml:"authentication"`
 		} `yaml:"metrics"`
+	}
+
+	// HTTPHeaders holds the daemon's HTTP response header settings.
+	HTTPHeaders struct {
+		AccessControlAllowOrigins        []string `yaml:"access_control_allow_origins"`
+		AccessControlAllowOriginWildcard bool     `yaml:"access_control_allow_origin_wildcard"`
+		AccessControlMaxAge              string   `yaml:"access_control_max_age" validate:"required"`
+		CookieDomain                     string   `yaml:"cookie_domain" validate:"required"`
 	}
 
 	// Log bundles several logging instances.

--- a/internal/utils/validation/validation.go
+++ b/internal/utils/validation/validation.go
@@ -67,6 +67,7 @@ func NewValidator() *val.Validate {
 	})
 
 	v.RegisterStructValidation(validateOpenIDMode, config.Mode{})
+	v.RegisterStructValidation(validateHTTPHeaders, config.HTTPHeaders{})
 
 	return v
 }
@@ -114,5 +115,15 @@ func validateOpenIDMode(sl val.StructLevel) {
 		reportIfEmpty(o.ChorusFrontendRedirectURL, "openid.chorus_frontend_redirect_url", "OpenID.ChorusFrontendRedirectURL")
 	} else {
 		reportIfEmpty(o.ChorusBackendHost, "openid.chorus_backend_host", "OpenID.ChorusBackendHost")
+	}
+}
+
+// validateHTTPHeaders rejects wildcard mode combined with a non-empty
+// allowlist - browsers reject a credentialed "*" response, so the
+// combination is always dead configuration.
+func validateHTTPHeaders(sl val.StructLevel) {
+	headers := sl.Current().Interface().(config.HTTPHeaders)
+	if len(headers.AccessControlAllowOrigins) > 0 && headers.AccessControlAllowOriginWildcard {
+		sl.ReportError(headers.AccessControlAllowOriginWildcard, "access_control_allow_origin_wildcard", "AccessControlAllowOriginWildcard", "wildcard_with_allowlist", "")
 	}
 }


### PR DESCRIPTION
internal/config/config.go: extracted Daemon.HTTP.Headers from an anonymous struct into a named HTTPHeaders type (matching the Mode/OpenID convention).

internal/utils/validation/validation.go: added validateHTTPHeaders, a struct-level validator rejecting access_control_allow_origin_wildcard: true whenever access_control_allow_origins is non-empty.

internal/cmd/provider/config.go: added a friendly error message for the new wildcard_with_allowlist tag.