### PR TITLE
Use app_sync instead of app-sync for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Postgres — run `make deps` to start it locally.
 
 ## Advanced Configuration
 
+### Naming Convention
+
+The backend's own config schema (everything under `internal/config/config.go`, i.e. every field documented in this section) uses **snake_case**, e.g. `daemon.http.headers.access_control_allow_origins`. This is deliberate, not an oversight: Viper lowercases every key inside any `map[string]...`-typed field during decode (`Log.Loggers`, `Daemon.Jobs`, `Storage.Datastores`, `Storage.FileStores`, `Services.AuthenticationService.Modes`), regardless of how it's written in the file — so a camelCase field like `appSync` would silently decode as `appsync`, breaking any Go code that looks it up by exact name (e.g. `internal/cmd/provider/jobber.go` dispatching a job by its config key). Since that limitation applies schema-wide in practice, the whole backend config stays snake_case for consistency, including named map instances like the `app_sync` job or the `chorus`/`audit` datastores.
+
+This is separate from the Helm chart's own `values.yaml` (`deploy/backend/values.yaml`, `configs/*/values.yaml`), which follows the standard Helm/Kubernetes convention of camelCase (`imagePullPolicy`, `podLabels`, etc.) for its own chart-level fields — everything *outside* the `config:` block that gets passed straight through into `configs/config.yaml` as-is.
+
 ### Build a Full Config
 
 `chorus init-config` (see [Quick Start](#quick-start)) covers local dev in one command. If you'd rather see every overridable field yourself and hand-edit `configs/config.yaml`, build it from the code-level defaults instead:

--- a/internal/cmd/provider/config.go
+++ b/internal/cmd/provider/config.go
@@ -136,7 +136,7 @@ func formatValidationError(cfg config.Config, fe val.FieldError) string {
 // siblingPath resolves a required_if/required_without Param (a Go field name
 // within the same parent struct) to its full dotted yaml path, e.g. "Enabled"
 // on Config.Clients.K8sClient.DefaultRegistry becomes "clients.kubernetes.enabled".
-// Parent segments may be map-indexed (e.g. "Jobs[app-sync]") when the field
+// Parent segments may be map-indexed (e.g. "Jobs[app_sync]") when the field
 // lives inside a map, as with Daemon.Jobs. Falls back to the raw Go field name
 // if anything doesn't resolve cleanly.
 func siblingPath(cfg config.Config, fe val.FieldError, goFieldName string) string {
@@ -299,10 +299,10 @@ func SetDefaultConfig(v *viper.Viper) {
 	v.SetDefault("daemon.totp.num_recovery_codes", 10)
 
 	// Daemon - Jobs
-	v.SetDefault("daemon.jobs.app-sync.enabled", true)
-	v.SetDefault("daemon.jobs.app-sync.interval", 30*time.Minute)
-	v.SetDefault("daemon.jobs.app-sync.timeout", 10*time.Minute)
-	v.SetDefault("daemon.jobs.app-sync.options", map[string]interface{}{"tenant_id": 1, "user_id": 1})
+	v.SetDefault("daemon.jobs.app_sync.enabled", true)
+	v.SetDefault("daemon.jobs.app_sync.interval", 30*time.Minute)
+	v.SetDefault("daemon.jobs.app_sync.timeout", 10*time.Minute)
+	v.SetDefault("daemon.jobs.app_sync.options", map[string]interface{}{"tenant_id": 1, "user_id": 1})
 
 	// Daemon - Jobber
 	v.SetDefault("daemon.jobber.enabled", true)

--- a/internal/cmd/provider/jobber.go
+++ b/internal/cmd/provider/jobber.go
@@ -50,7 +50,7 @@ func InitDaemonJobs() {
 	for name, jobConfig := range cfg.Daemon.Jobs {
 		var j job.Job
 		switch name {
-		case "app-sync":
+		case "app_sync":
 			registry := ""
 			if u, err := url.Parse(cfg.Clients.HarborClient.URL); err == nil {
 				registry = u.Host

--- a/pkg/app/service/sync-job.go
+++ b/pkg/app/service/sync-job.go
@@ -89,14 +89,14 @@ func (j *AppSyncJob) Do(ctx context.Context, options map[string]interface{}) (st
 	for _, a := range existingApps {
 		existing[appIdentity(a)] = struct{}{}
 	}
-	logger.TechLog.Debug(ctx, fmt.Sprintf("app-sync: listed %d existing apps", len(existingApps)))
+	logger.TechLog.Debug(ctx, fmt.Sprintf("app_sync: listed %d existing apps", len(existingApps)))
 
 	// List apps and versions in Harbor
 	harborApps, err := j.harborClient.ListApps()
 	if err != nil {
 		return "", fmt.Errorf("listing apps from harbor: %w", err)
 	}
-	logger.TechLog.Debug(ctx, fmt.Sprintf("app-sync: listed %d apps from harbor", len(harborApps)))
+	logger.TechLog.Debug(ctx, fmt.Sprintf("app_sync: listed %d apps from harbor", len(harborApps)))
 
 	toCreate := j.appsToCreate(harborApps, existing, tenantID, userID)
 	if len(toCreate) == 0 {

--- a/scripts/run_acceptance_tests.sh
+++ b/scripts/run_acceptance_tests.sh
@@ -19,7 +19,7 @@ fi
 
 COVERAGE_DIR="${COVERAGE_DIR:-tests/coverage}"
 CONFIG_FILE="${CONFIG_FILE:-configs/config.yaml}"
-ACCEPTANCE_CONFIG_SET="${ACCEPTANCE_CONFIG_SET:-storage.datastores.chorus.database=chorus_ci,storage.file_stores.disk.disk_config.base_path=docker/.diskfilestoreci,clients.docker_client.enabled=false,clients.k8s_client.enabled=false}"
+ACCEPTANCE_CONFIG_SET="${ACCEPTANCE_CONFIG_SET:-storage.datastores.chorus.database=chorus_ci,storage.file_stores.disk.disk_config.base_path=docker/.diskfilestoreci,clients.docker.enabled=false,clients.kubernetes.enabled=false}"
 
 # go test runs each suite with its package directory as the working directory
 # (tests/acceptance/<suite>), not the repo root, so the path handed to it must


### PR DESCRIPTION
use snakecase consistently for backend configs
add explanations in readme about why we're using snake case for backend configs and not camel case