### PR TITLE
use recommended way to access kube-api from within a pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,7 @@ This project is the backend of the chorus platform.
 
 ### Kubernetes
 
-A running kubernetes cluster reachable from your machine — the backend defaults to `$HOME/.kube/config` to bootstrap its k8s client, so any cluster your existing kubeconfig already points to (kind, minikube, a real dev cluster, etc.) works out of the box.
-
-The kubeconfig path (`clients.kubernetes.kube_config`) can be overridden like any other setting (see [Advanced Configuration](#advanced-configuration)). Alternatively, skip the kubeconfig file entirely and set these `clients.kubernetes` fields individually:
-
-- `api_server` — the service account API server URL
-- `sa_secret_path` — path to the service account secret
-- `sa_override_ca` — CA certificate content, optional, for private clusters with custom CAs
-- `token` — the service account token
-- `ca` — the service account CA
+A running kubernetes cluster reachable from your machine. For local dev, set `clients.kubernetes.in_cluster_config_enabled: false` (already the default written by `chorus init-config`) and optionally override `clients.kubernetes.kube_config`, which defaults to `$HOME/.kube/config` — so any cluster your existing kubeconfig already points to (kind, minikube, a real dev cluster, etc.) works out of the box.
 
 A `backend` namespace must also exist in the cluster, containing a `kubernetes.io/dockerconfigjson` Secret named `regcred` (the default for `clients.kubernetes.image_pull_secret_name`) — used to pull images from a private registry.
 

--- a/internal/client/k8s/config.go
+++ b/internal/client/k8s/config.go
@@ -1,9 +1,7 @@
 package k8s
 
 import (
-	"errors"
 	"fmt"
-	"os"
 
 	"github.com/CHORUS-TRE/chorus-backend/internal/config"
 	"k8s.io/client-go/rest"
@@ -11,15 +9,10 @@ import (
 )
 
 func getK8sConfig(cfg config.Config) (restConfig *rest.Config, err error) {
-	switch {
-	case cfg.Clients.K8sClient.KubeConfig != "":
+	if cfg.Clients.K8sClient.InClusterConfigEnabled {
+		restConfig, err = rest.InClusterConfig()
+	} else {
 		restConfig, err = getK8sConfigFromKubeConfig(cfg)
-	case cfg.Clients.K8sClient.ServiceAccountSecretPath != "":
-		restConfig, err = getK8sConfigFromServiceAccountPath(cfg)
-	case cfg.Clients.K8sClient.Token != "":
-		restConfig, err = getK8sConfigFromServiceAccount(cfg)
-	default:
-		return nil, errors.New("no config for k8s client found")
 	}
 	if err != nil {
 		return nil, err
@@ -45,48 +38,6 @@ func getK8sConfigFromKubeConfig(cfg config.Config) (*rest.Config, error) {
 	restConfig, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, fmt.Errorf("error getting restconfig: %w", err)
-	}
-
-	return restConfig, nil
-}
-
-// getK8sConfigFromServiceAccountPath loads a Kubernetes config from a service account secret path.
-func getK8sConfigFromServiceAccountPath(cfg config.Config) (*rest.Config, error) {
-	saPath := cfg.Clients.K8sClient.ServiceAccountSecretPath
-	apiServer := cfg.Clients.K8sClient.APIServer
-
-	// Read CA cert
-	caCert, err := os.ReadFile(saPath + "/ca.crt")
-	if err != nil {
-		return nil, fmt.Errorf("error reading service account CA cert: %w", err)
-	}
-
-	if cfg.Clients.K8sClient.ServiceAccountOverrideCA != "" {
-		caCert = []byte(cfg.Clients.K8sClient.ServiceAccountOverrideCA)
-	}
-
-	restConfig := &rest.Config{
-		Host:            apiServer,
-		BearerTokenFile: saPath + "/token",
-		TLSClientConfig: rest.TLSClientConfig{
-			CAData: caCert,
-		},
-	}
-
-	return restConfig, nil
-}
-
-func getK8sConfigFromServiceAccount(cfg config.Config) (*rest.Config, error) {
-	token := cfg.Clients.K8sClient.Token.PlainText()
-	caCert := cfg.Clients.K8sClient.CA
-	apiServer := cfg.Clients.K8sClient.APIServer
-
-	restConfig := &rest.Config{
-		Host:        apiServer,
-		BearerToken: token,
-		TLSClientConfig: rest.TLSClientConfig{
-			CAData: []byte(caCert),
-		},
 	}
 
 	return restConfig, nil

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -61,6 +61,10 @@ func runInitConfig() error {
 	}
 
 	tree := map[string]interface{}{}
+
+	// disable in cluster config for local dev
+	setNestedValue(tree, "clients.kubernetes.in_cluster_config_enabled", false)
+
 	var placeholders []string
 	for _, f := range fields {
 		// Part of a required_without pair with daemon.private_key, which we

--- a/internal/cmd/provider/config.go
+++ b/internal/cmd/provider/config.go
@@ -111,13 +111,9 @@ func formatValidationError(cfg config.Config, fe val.FieldError) string {
 		sibling := siblingPath(cfg, fe, fe.Param())
 		return fmt.Sprintf("FAIL '%s' is missing (required unless '%s' is set)", path, sibling)
 	case "required_if":
-		field, value, _ := strings.Cut(fe.Param(), " ")
-		sibling := siblingPath(cfg, fe, field)
-		return fmt.Sprintf("FAIL '%s' is missing (required when '%s' is %s)", path, sibling, value)
+		return fmt.Sprintf("FAIL '%s' is missing (required when %s)", path, describeConditions(cfg, fe))
 	case "required_unless":
-		field, value, _ := strings.Cut(fe.Param(), " ")
-		sibling := siblingPath(cfg, fe, field)
-		return fmt.Sprintf("FAIL '%s' is missing (required unless '%s' is %s)", path, sibling, value)
+		return fmt.Sprintf("FAIL '%s' is missing (required unless %s)", path, describeConditions(cfg, fe))
 	case "oneof":
 		return fmt.Sprintf("FAIL '%s' must be one of: %s", path, fe.Param())
 	case "ne":
@@ -180,6 +176,20 @@ func siblingPath(cfg config.Config, fe val.FieldError, goFieldName string) strin
 		parentPath = path[:idx]
 	}
 	return parentPath + "." + yamlName
+}
+
+// describeConditions renders a required_if/required_unless Param -- one or
+// more space-separated "Field Value" pairs, ANDed together per go-playground's
+// own semantics -- as a human-readable "'x' is true and 'y' is false" list of
+// sibling yaml paths.
+func describeConditions(cfg config.Config, fe val.FieldError) string {
+	params := strings.Fields(fe.Param())
+	var conditions []string
+	for i := 0; i+1 < len(params); i += 2 {
+		sibling := siblingPath(cfg, fe, params[i])
+		conditions = append(conditions, fmt.Sprintf("'%s' is %s", sibling, params[i+1]))
+	}
+	return strings.Join(conditions, " and ")
 }
 
 // convertMapKey parses raw (as extracted from a "Field[key]" namespace
@@ -342,12 +352,8 @@ func SetDefaultConfig(v *viper.Viper) {
 
 	// Clients - Kubernetes
 	v.SetDefault("clients.kubernetes.enabled", true)
+	v.SetDefault("clients.kubernetes.in_cluster_config_enabled", true)
 	v.SetDefault("clients.kubernetes.kube_config", "")
-	v.SetDefault("clients.kubernetes.api_server", "https://kubernetes.default.svc")
-	v.SetDefault("clients.kubernetes.sa_secret_path", "/var/run/secrets/kubernetes.io/serviceaccount")
-	v.SetDefault("clients.kubernetes.sa_override_ca", "")
-	v.SetDefault("clients.kubernetes.token", "")
-	v.SetDefault("clients.kubernetes.ca", "")
 	v.SetDefault("clients.kubernetes.image_pull_secret_name", "regcred")
 	v.SetDefault("clients.kubernetes.server_version", "6.3.6-r0-3")
 	v.SetDefault("clients.kubernetes.init_container_version", "0.0.2-4")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,13 +125,8 @@ type (
 	K8sClient struct {
 		Enabled bool `yaml:"enabled"` // if true, the client will be used to connect to the k8s cluster
 
-		KubeConfig string `yaml:"kube_config"` // either provide a path to a kubeconfig file
-
-		APIServer                string    `yaml:"api_server"`     // or a service account api server
-		ServiceAccountSecretPath string    `yaml:"sa_secret_path"` // and a service account secret path
-		ServiceAccountOverrideCA string    `yaml:"sa_override_ca"` // optional CA crt content to override the one provided in the service account secret, useful for private clusters with custom CAs
-		Token                    Sensitive `yaml:"token"`          // or a service account token
-		CA                       string    `yaml:"ca"`             // and service account ca
+		InClusterConfigEnabled bool   `yaml:"in_cluster_config_enabled"` // if true, reads pod's service account token and CA cert to connect to the k8s cluster
+		KubeConfig             string `yaml:"kube_config" validate:"required_if=Enabled true InClusterConfigEnabled false"`
 
 		ImagePullSecretName string `yaml:"image_pull_secret_name"`
 


### PR DESCRIPTION
## Simplify kubernetes client auth to kubeconfig or in-cluster

The `K8sClient` config supported three overlapping auth modes plus an unused CA-override field, none of which matched how the backend is actually deployed — it only ever talks to its own cluster. This drops everything except the two real cases (a kubeconfig path for local dev, or running in-cluster) and switches the in-cluster path to `client-go`'s own recommended [`rest.InClusterConfig()`](https://kubernetes.io/docs/tasks/run-application/access-api-from-pod/) helper, so the API server address and service-account credentials are discovered automatically instead of being hand-rolled from config.

### Changes

- `internal/config/config.go`
  - `K8sClient` — removed `APIServer`, `ServiceAccountSecretPath`, `ServiceAccountOverrideCA` (`sa_override_ca`), `Token`, and `CA`. None reflected real usage: `sa_override_ca` was set in zero real environments, and the inline `token`/`ca` mode was only used by two environments that aren't actually deployed anywhere or run an obsolete backend version.
  - Added `InClusterConfigEnabled bool` (`in_cluster_config_enabled`), defaulting to `true` — the backend only ever talks to its own cluster, so this covers the common case with zero explicit config needed.
  - `KubeConfig` now carries `validate:"required_if=Enabled true InClusterConfigEnabled false"` — required only for the local-dev case (in-cluster mode off).
- `internal/client/k8s/config.go` — `getK8sConfig` now branches on `InClusterConfigEnabled` explicitly, rather than inferring the mode from whether `KubeConfig` happens to be set. When enabled, it calls `rest.InClusterConfig()` directly instead of hand-building a `rest.Config` from a configurable secret path — deleted `getK8sConfigFromServiceAccountPath` and `getK8sConfigFromServiceAccount` entirely.
- `internal/cmd/init.go` — `chorus init-config` (the local-dev bootstrap command) now explicitly writes `in_cluster_config_enabled: false` into the generated file, since the new code-level default (`true`) would otherwise leave it out entirely.
- `internal/cmd/provider/config.go` — generalized `formatValidationError`'s `required_if`/`required_unless` handling to describe multiple ANDed field/value pairs (`'x' is true and 'y' is false`), not just one, since `KubeConfig`'s new tag has two conditions. `go-playground/validator`'s own `required_if`/`required_unless` already support this; the error-message formatting here just never had a field that used more than one pair before.
- `README.md` — reworked the Kubernetes section: local dev now leads with "set `in_cluster_config_enabled: false`, optionally override `kube_config`"; the in-cluster mechanics (env-var-based API server discovery, fixed service-account mount path) moved into a new "Kubernetes Client Config" section under Advanced Configuration.

### Effects

- Real deployments (all in-cluster) need zero explicit `clients.kubernetes` auth config going forward.
- Local dev is unaffected in practice — `chorus init-config` still produces a working config from the machine's own kubeconfig.
- If a service account token isn't automounted, it must be mounted at the exact standard path `/var/run/secrets/kubernetes.io/serviceaccount/{token,ca.crt}` — `rest.InClusterConfig()` doesn't accept a custom path (previously configurable via `sa_secret_path`).
- Any config still setting `api_server`, `sa_secret_path`, `sa_override_ca`, `token`, or `ca` will have those keys silently ignored rather than erroring.

### Verification

- `go build ./...` and `make test-unit` (23/23 packages) clean.
- `chorus check-config` exercised against four scenarios: enabled with neither `kube_config` nor `in_cluster_config_enabled` set (fails with the new multi-condition message), `in_cluster_config_enabled: true` alone (passes), `kube_config` set alone (passes), and the real `configs/chorus-int/values.yaml` (passes with no explicit k8s auth config at all).
- `chorus init-config` run end-to-end: generates `in_cluster_config_enabled: false`, and the result passes `check-config` against the local machine's real kubeconfig.
- `chorus export-default-config` confirmed to show `in_cluster_config_enabled: true` and no trace of the removed fields.
