### PR TITLE
Key OpenID Connect provider clients by client_id instead of a list

### DIFF
--- a/configs/chorus-int/values.yaml
+++ b/configs/chorus-int/values.yaml
@@ -93,7 +93,20 @@ config:
       issuer_url: "https://backend.int.chorus-tre.ch/openid-connect"
       frontend_interactions_url: "https://backend.int.chorus-tre.ch/auth-ui"
       jwks: "" # set in secret
-      clients: [] # set in secret
+      clients:
+        gitlab:
+          client_name: "Gitlab int Chorus OIDC Client"
+          client_secret: "" # set in secret
+          redirect_uris:
+            - "https://gitlab.int.chorus-tre.ch/users/auth/openid_connect/callback"
+          grant_types:
+            - authorization_code
+            - refresh_token
+          response_types:
+            - code
+          scope: "openid profile email roles"
+          token_endpoint_auth_method: "client_secret_post"
+          only_pre_logged_for_client: false
     steward:
       user:
         password: "" # set in secret

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -274,12 +274,12 @@ type (
 		} `yaml:"authentication_service"`
 
 		OpenIDConnectProvider struct {
-			Enabled                 bool                          `yaml:"enabled"`
-			FrontendInteractionsURL string                        `yaml:"frontend_interactions_url" validate:"required_if=Enabled true"`
-			JWKS                    Sensitive                     `yaml:"jwks" validate:"required_if=Enabled true" init:"jwks"`
-			IssuerURL               string                        `yaml:"issuer_url" validate:"required_if=Enabled true"`
-			Scopes                  []string                      `yaml:"scopes"`
-			Clients                 []OpenIDConnectProviderClient `yaml:"clients" validate:"required_if=Enabled true,dive"`
+			Enabled                 bool                                   `yaml:"enabled"`
+			FrontendInteractionsURL string                                 `yaml:"frontend_interactions_url" validate:"required_if=Enabled true"`
+			JWKS                    Sensitive                              `yaml:"jwks" validate:"required_if=Enabled true" init:"jwks"`
+			IssuerURL               string                                 `yaml:"issuer_url" validate:"required_if=Enabled true"`
+			Scopes                  []string                               `yaml:"scopes"`
+			Clients                 map[string]OpenIDConnectProviderClient `yaml:"clients" validate:"required_if=Enabled true,dive"`
 		} `yaml:"openid_connect_provider"`
 
 		WorkbenchService struct {
@@ -376,10 +376,9 @@ type (
 	}
 
 	OpenIDConnectProviderClient struct {
-		ID string `yaml:"client_id" validate:"required"`
-		// Secret is used when the client authenticates with client_secret_jwt,
-		// since the key used to sign the assertion is the same used to verify it.
-		Secret Sensitive `yaml:"client_secret"`
+		// Secret is required unless the client authenticates via private_key_jwt
+		// (which proves possession of a key pair instead of a shared secret).
+		Secret Sensitive `yaml:"client_secret" validate:"required_unless=TokenAuthnMethod private_key_jwt"`
 		// HashedSecret is the hash of the client secret for the client_secret_basic
 		// and client_secret_post authentication methods.
 		HashedSecret Sensitive `yaml:"hashed_secret"`
@@ -423,13 +422,16 @@ type (
 		RequestURIs       []string `yaml:"request_uris"`
 		GrantTypes        []string `yaml:"grant_types"`    // client_credentials, authorization_code, refresh_token, implicit
 		ResponseTypes     []string `yaml:"response_types"` // code, id_token, token, code id_token, code token, id_token token, code id_token token
-		PublicJWKSURI     string   `yaml:"jwks_uri"`
+		PublicJWKSURI     string   `yaml:"jwks_uri" validate:"required_if=TokenAuthnMethod private_key_jwt"`
 		// PublicJWKS        *JSONWebKeySet `yaml:"jwks"`
 		// ScopeIDs contains the scopes available to the client separated by spaces.
 		ScopeIDs string `yaml:"scope"`
 		//...
 
-		TokenAuthnMethod string `yaml:"token_endpoint_auth_method"` // none, client_secret_basic, client_secret_post, client_secret_jwt, private_key_jwt, tls_client_auth, self_signed_tls_client_auth, dpop
+		// TokenAuthnMethod is constrained to the methods actually enabled by
+		// the provider (see WithTokenAuthnMethods in oidc-idp.go) -- not the
+		// full set the underlying OIDC library supports.
+		TokenAuthnMethod string `yaml:"token_endpoint_auth_method" validate:"oneof=client_secret_basic client_secret_post private_key_jwt"`
 	}
 
 	// UserDelegationConfig configures a client to act on behalf of a specific

--- a/pkg/oidc-idp/service/authutil/authn-policy.go
+++ b/pkg/oidc-idp/service/authutil/authn-policy.go
@@ -139,14 +139,8 @@ func (a authenticator) loadUser(r *http.Request, as *goidc.AuthnSession) (goidc.
 	}
 
 	clientID := as.ClientID
-	var client *config.OpenIDConnectProviderClient
-	for _, c := range a.cfg.Services.OpenIDConnectProvider.Clients {
-		if c.ID == clientID {
-			client = &c
-			break
-		}
-	}
-	if client == nil {
+	client, ok := a.cfg.Services.OpenIDConnectProvider.Clients[clientID]
+	if !ok {
 		return goidc.StatusFailure, errors.New("client not found")
 	}
 
@@ -236,14 +230,8 @@ func (a authenticator) createUserSession(w http.ResponseWriter, as *goidc.AuthnS
 
 func (a authenticator) grantConsent(w http.ResponseWriter, r *http.Request, as *goidc.AuthnSession) (goidc.Status, error) {
 	clientID := as.ClientID
-	var client *config.OpenIDConnectProviderClient
-	for _, c := range a.cfg.Services.OpenIDConnectProvider.Clients {
-		if c.ID == clientID {
-			client = &c
-			break
-		}
-	}
-	if client == nil {
+	client, ok := a.cfg.Services.OpenIDConnectProvider.Clients[clientID]
+	if !ok {
 		return goidc.StatusFailure, errors.New("client not found")
 	}
 	if client.GrantAutoApproved {
@@ -325,7 +313,7 @@ func (a authenticator) grantConsent(w http.ResponseWriter, r *http.Request, as *
 		newGrants = append(newGrants, user_model.UserGrant{
 			TenantID:     user.TenantID,
 			UserID:       user.ID,
-			ClientID:     client.ID,
+			ClientID:     clientID,
 			Scope:        s,
 			GrantedUntil: grantedUntil,
 		})

--- a/pkg/oidc-idp/service/client-manager.go
+++ b/pkg/oidc-idp/service/client-manager.go
@@ -21,7 +21,7 @@ var _ goidc.ClientManager = &clientManager{}
 func NewClientManager(cfg config.Config) (*clientManager, error) {
 	cs := make(map[string]*goidc.Client, len(cfg.Services.OpenIDConnectProvider.Clients))
 
-	for _, c := range cfg.Services.OpenIDConnectProvider.Clients {
+	for id, c := range cfg.Services.OpenIDConnectProvider.Clients {
 		gt := make([]goidc.GrantType, len(c.GrantTypes))
 		for i, grantType := range c.GrantTypes {
 			gt[i] = goidc.GrantType(grantType)
@@ -38,7 +38,7 @@ func NewClientManager(cfg config.Config) (*clientManager, error) {
 		}
 
 		client := &goidc.Client{
-			ID:                         c.ID,
+			ID:                         id,
 			Secret:                     c.Secret.PlainText(),
 			HashedSecret:               string(h),
 			CreatedAtTimestamp:         c.CreatedAtTimestamp,
@@ -66,14 +66,14 @@ func NewClientManager(cfg config.Config) (*clientManager, error) {
 
 		if c.UserDelegation != nil {
 			if c.GrantTypes == nil || len(c.GrantTypes) != 1 || c.GrantTypes[0] != string(goidc.GrantClientCredentials) {
-				return nil, fmt.Errorf("client %s has user delegation configured, it needs to have a single grant type: client_credentials", c.ID)
+				return nil, fmt.Errorf("client %s has user delegation configured, it needs to have a single grant type: client_credentials", id)
 			}
 			client.SetCustomAttribute("user_delegation_user_id", c.UserDelegation.UserID)
 			client.SetCustomAttribute("user_delegation_tenant_id", c.UserDelegation.TenantID)
 			client.SetCustomAttribute("user_delegation_claims", c.UserDelegation.Claims)
 		}
 
-		cs[c.ID] = client
+		cs[id] = client
 	}
 
 	return &clientManager{


### PR DESCRIPTION
## Key OpenID Connect provider clients by client_id instead of a list

The registered OIDC clients (`services.openid_connect_provider.clients`) were a plain list, which meant a secrets file could never override just one client's secret — Viper's config-file merge replaces arrays wholesale rather than merging by index, so injecting a real `client_secret` required repeating that client's entire block (redirect URIs, grant types, etc.) inside the secret. Switching to a map keyed by `client_id` fixes that, matching how every other secret-bearing field in this schema is split between the plain config and its secret. Along the way, this also closes two validation gaps: a client's `client_secret` was never actually required, and `private_key_jwt` clients had no way to be checked for the public key material they need instead of a secret.

### Changes

- `internal/config/config.go`
  - `OpenIDConnectProvider.Clients` changed from `[]OpenIDConnectProviderClient` to `map[string]OpenIDConnectProviderClient`, keyed by `client_id`. Config files are merged map-by-map, but a list is replaced wholesale — the map lets a secrets file override a single client's `client_secret` without repeating its other fields.
  - Dropped the now-redundant `ID`/`client_id` field from `OpenIDConnectProviderClient` — the map key is the client's identity everywhere now, matching how `AuthenticationService.Modes map[string]Mode` already works (no self-identifying field duplicating its own map key).
  - `Secret` gained `validate:"required_unless=TokenAuthnMethod private_key_jwt"` — a client's secret was previously optional in config regardless of its auth method, so a missing one would silently ship rather than fail `check-config`.
  - `TokenAuthnMethod` gained `validate:"oneof=client_secret_basic client_secret_post private_key_jwt"` — constrained to the three methods the provider actually enables (`WithTokenAuthnMethods` in `oidc-idp.go`); the old comment listed all eight methods the underlying OIDC library supports, which was misleading.
  - `PublicJWKSURI` (`jwks_uri`) gained `validate:"required_if=TokenAuthnMethod private_key_jwt"` — `private_key_jwt` clients authenticate via a signed JWT verified against their public JWKS, and `jwks_uri` is the only way this config supports supplying that (inline JWKS is commented out, never wired up). Without this, a `private_key_jwt` client could pass `check-config` with no secret *and* no key material, then fail every real authentication attempt at runtime instead.
- `pkg/oidc-idp/service/client-manager.go`
  - `NewClientManager` now ranges with `for id, c := range Clients`, using the map key for `goidc.Client.ID`, the user-delegation error message, and the `cs[id]` map entry — previously all three read the (now-removed) `c.ID` field.
- `pkg/oidc-idp/service/authutil/authn-policy.go`
  - `loadUser` and `grantConsent` each did a linear `for _, c := range Clients { if c.ID == clientID }` scan to find a client by ID — replaced with a direct `Clients[clientID]` map lookup in both.
- `configs/chorus-int/values.yaml`
  - Moved the `gitlab` OIDC client's full definition (name, redirect URIs, grant types, scope, auth method) out of the secret and into the plain config, leaving only `client_secret: ""  # set in secret` to be injected — the split this whole change was meant to enable.

### Effects

- `services.openid_connect_provider.clients` is now a map; any client entry no longer needs (or accepts) its own `client_id` field — the map key is the identity.
- A secrets file can now override a single client's `client_secret` in isolation, without repeating that client's other fields.
- `check-config` now fails on a client with no secret and no `private_key_jwt`/`jwks_uri` combination, instead of silently accepting a client that can never actually authenticate.
- chorus-int's k8s Secret still needs updating: it currently sets the client under the old list-shaped key and must move to `services.openid_connect_provider.clients.gitlab.client_secret` for the real secret to land correctly.

### Verification

- `go build ./...` and `make test-unit` (23/23 packages) clean.
- End-to-end through the real `config.Config` struct with a split main-config/secrets-file pair: confirmed a targeted `clients.gitlab.client_secret` override in the secret lands correctly while `gitlab`'s other fields and an unrelated sibling client entry stay untouched.
- Exercised all three real auth methods directly against the validator: `client_secret_basic`/`client_secret_post` with a secret (pass), `private_key_jwt` with `jwks_uri` (pass), `private_key_jwt` without `jwks_uri` (fails on the right field), and a disabled method like `dpop` (fails `oneof`).
- `check-config` against chorus-int's actual `.config` subtree: only the expected "set in secret" placeholder failures remain, including the now-caught missing `clients[gitlab].client_secret`.

### Secrets to create before rollout

- chorus-int's backend Secret needs its OIDC client entry moved from the old list-shaped `clients` key to `services.openid_connect_provider.clients.gitlab.client_secret` before this rolls out, or the `gitlab` client will fail `check-config`'s new `required_unless` check.
