### PR TITLE
Load config secrets from a Secret's env vars instead of a mounted secrets.yaml

### DIFF
--- a/configs/chorus-int/values.yaml
+++ b/configs/chorus-int/values.yaml
@@ -11,10 +11,6 @@ serviceMonitor:
     enabled: true
     secretName: "chorus-int-backend-metrics"
 
-# Disable mounting of secrets volume and config override
-# all password will need to be set via the config below
-# which is not recommended for production use cases
-disableMountSecrets: false
 config:
   clients:
     oci:

--- a/configs/ci/values.yaml
+++ b/configs/ci/values.yaml
@@ -123,10 +123,6 @@ affinity: {}
 clusterRole:
   create: false
 
-# Disable mounting of secrets volume and config override
-# all password will need to be set via the config below
-# which is not recommended for production use cases
-disableMountSecrets: true
 config:
   clients:
     oci:

--- a/deploy/backend/templates/deployment.yaml
+++ b/deploy/backend/templates/deployment.yaml
@@ -40,10 +40,6 @@ spec:
             - start
             - --config
             - /configs/config.yaml
-            {{- if not .Values.disableMountSecrets }}
-            - --config
-            - /secrets/secrets.yaml
-            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "backend.image" . }}
@@ -52,8 +48,11 @@ spec:
           env:
             {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- with .Values.envFrom }}
           envFrom:
+          - secretRef:
+              name: {{ include "backend.fullname" . }}
+              optional: true
+          {{- with .Values.envFrom }}
             {{- toYaml . | nindent 10 }}
           {{- end }}
           resources:
@@ -69,10 +68,6 @@ spec:
           volumeMounts:
           - name: config
             mountPath: /configs
-          {{- if not .Values.disableMountSecrets }}
-          - name: secrets
-            mountPath: /secrets
-          {{- end }}
       volumes:
       - name: config
         configMap:
@@ -80,14 +75,6 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
-      {{- if not .Values.disableMountSecrets }}
-      - name: secrets
-        secret:
-          secretName: {{ include "backend.fullname" . }}
-          items:
-          - key: secrets.yaml
-            path: secrets.yaml
-      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/backend/values.yaml
+++ b/deploy/backend/values.yaml
@@ -125,10 +125,6 @@ affinity: {}
 clusterRole:
   create: true
 
-# Disable mounting of secrets volume and config override
-# all password will need to be set via the config below
-# which is not recommended for production use cases
-disableMountSecrets: false
 # The whole config section is passed to the backend as a config file, so you can override any config value here.
 # You can use chorus-backend/configs/chorus-int/values.yaml as a reference for the default values.
 config: {}


### PR DESCRIPTION
## Load config secrets from a Secret's env vars instead of a mounted secrets.yaml

Secrets were previously injected by mounting a Secret as a second config file (`--config /secrets/secrets.yaml`), gated by `disableMountSecrets`. This switches to `envFrom.secretRef`, injecting every key in the release's Secret as an environment variable — Viper's existing `CHORUS_*` env var convention (a dotted config path uppercased with underscores, e.g. `clients.oci.password` → `CHORUS_CLIENTS_OCI_PASSWORD`) then applies these overrides during config resolution, the same way it already does for any other env-based override. `disableMountSecrets` and the whole secrets-volume mechanism are removed.

### Changes

- `deploy/backend/templates/deployment.yaml`
  - Removed the `disableMountSecrets`-gated `--config /secrets/secrets.yaml` arg, the `secrets` volumeMount, and the `secrets` volume (backed by a `secretName: secrets.yaml` key) entirely.
  - `envFrom` is now unconditional: `- secretRef: {name: {{ include "backend.fullname" . }}, optional: true}` — same Secret name/object as before, just read as individual keys instead of a single `secrets.yaml` blob. `optional: true` so a Secret missing a key (or missing entirely) doesn't fail pod scheduling, matching the old mechanism's tolerance for a config field simply not being set.
  - Any environment-supplied `.Values.envFrom`/`.Values.env` entries still render after the fixed one, unchanged.
- `deploy/backend/values.yaml`, `configs/chorus-int/values.yaml`, `configs/ci/values.yaml`
  - Removed the now-dead `disableMountSecrets` field and its comment from all three.

### Effects

- Every secret field already present in the plain config as an empty placeholder (`password: ""  # set in secret`, etc.) picks up its real value from the Secret's matching `CHORUS_*` key — this covers fixed struct fields (`clients.oci.password`) and map-nested ones (OIDC/auth-mode client secrets, minio keys) alike, since `envFrom` doesn't require the chart to know key names in advance.
- No more `/secrets` volume or second `--config` layer in the pod spec.
- Existing `.Values.env`/`.Values.envFrom` overrides in any environment's values file are unaffected.

### Verification

- Confirmed via a standalone test against `internal/cmd/root.go`'s actual Viper setup (`SetEnvPrefix("CHORUS")`, `SetEnvKeyReplacer(".", "_")`, `AutomaticEnv()`) that a `CHORUS_*` env var only overrides a field through `Unmarshal` if that field's key is already known to Viper — true for every current secret field, since they're all already present as empty placeholders in the checked-in plain config.
- `helm lint` on the chart: clean (only the pre-existing, unrelated postgresql OCI-dependency warning).
- `helm template` rendered against default chart values and against chorus-int's real `values.yaml`: confirmed the `envFrom.secretRef` entry renders with the correct Secret name (`chorus-int-backend`), no `env:`/volume/secrets-mount leftovers, and that environment-supplied `.Values.env`/`.Values.envFrom` extras still append correctly alongside it.

### Secrets to create before rollout

- The release's Secret (`{{ include "backend.fullname" . }}`, e.g. `chorus-int-backend`) needs to be restructured from a single `secrets.yaml` key into individual `CHORUS_*`-named keys — one per secret field, matching the env var convention above — before this rolls out to any environment still using the old single-file Secret shape.
