### PR TITLE
remove "add user details" flag

### DIFF
--- a/internal/client/k8s/converters.go
+++ b/internal/client/k8s/converters.go
@@ -67,9 +67,9 @@ func (c *client) workbenchToK8sWorkbench(workbench Workbench) (K8sWorkbench, err
 		}
 	}
 
-	// Add user details if configured and not empty
+	// Add user details if not empty
 	username := workbench.SanitizedUsername()
-	if c.cfg.Clients.K8sClient.AddUserDetails && username != "" {
+	if username != "" {
 		k8sWorkbench.Spec.Server.User = username
 		k8sWorkbench.Spec.Server.UserID = int(workbench.UserID + workbenchUserIDOffset)
 	}

--- a/internal/cmd/provider/config.go
+++ b/internal/cmd/provider/config.go
@@ -362,7 +362,7 @@ func SetDefaultConfig(v *viper.Viper) {
 	v.SetDefault("clients.kubernetes.image_pull_secret_name", "regcred")
 	v.SetDefault("clients.kubernetes.server_version", "6.3.6-r0-3")
 	v.SetDefault("clients.kubernetes.init_container_version", "0.0.2-4")
-	v.SetDefault("clients.kubernetes.add_user_details", false)
+	v.SetDefault("clients.kubernetes.add_user_details", true)
 	v.SetDefault("clients.kubernetes.insecure_tls", false)
 	v.SetDefault("clients.kubernetes.is_watcher", true)
 	v.SetDefault("clients.kubernetes.poll_interval", 500*time.Millisecond)

--- a/internal/cmd/provider/config.go
+++ b/internal/cmd/provider/config.go
@@ -362,7 +362,6 @@ func SetDefaultConfig(v *viper.Viper) {
 	v.SetDefault("clients.kubernetes.image_pull_secret_name", "regcred")
 	v.SetDefault("clients.kubernetes.server_version", "6.3.6-r0-3")
 	v.SetDefault("clients.kubernetes.init_container_version", "0.0.2-4")
-	v.SetDefault("clients.kubernetes.add_user_details", true)
 	v.SetDefault("clients.kubernetes.insecure_tls", false)
 	v.SetDefault("clients.kubernetes.is_watcher", true)
 	v.SetDefault("clients.kubernetes.poll_interval", 500*time.Millisecond)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -132,7 +132,6 @@ type (
 
 		ServerVersion        string `yaml:"server_version" validate:"required_if=Enabled true"`
 		InitContainerVersion string `yaml:"init_container_version" validate:"required_if=Enabled true"`
-		AddUserDetails       bool   `yaml:"add_user_details"`
 
 		InsecureTLS bool `yaml:"insecure_tls"` // if true, TLS certificate verification is skipped (testing only)
 


### PR DESCRIPTION
## Always set app-instance user details, drop the `add_user_details` toggle

App instances were only running as the actual authenticated user when `clients.kubernetes.add_user_details` was explicitly set to `true`; otherwise `workbench-operator` fell back to its own fixed `"chorus"` user. The toggle never actually had a real "off while the K8s client is enabled" use case in any environment — every environment that runs real workbenches wants this on, and the one place that doesn't (CI) already disables the entire K8s client, which bypasses this code path regardless of the flag's value. Removing the config makes the intended behavior unconditional instead of opt-in-and-easy-to-forget.

### Changes

- `internal/config/config.go`
  - Removed `K8sClient.AddUserDetails` field (`add_user_details` yaml key) entirely.
- `internal/cmd/provider/config.go`
  - Removed the corresponding `SetDefault` call.
- `internal/client/k8s/converters.go`
  - `workbenchToK8sWorkbench` now sets `Spec.Server.User`/`UserID` whenever `username != ""`, with no config gate.

### Effects

- Every environment now gets real per-user identity (`USER`/`USER_ID`/`HOME`, and per-user storage-mount subpaths on the operator side) on every workbench, unconditionally — no per-environment config needed, and nothing to migrate in the `environments` repo.
- `clients.kubernetes.add_user_details` is no longer a recognized config key; any environment still setting it will have that key silently ignored (harmless, but worth cleaning up next time that file is touched).
- No effect on CI, which disables the K8s client entirely and never reaches this code path.

### Verification

- `go build ./...` and `make test-unit` (23/23 packages) clean.
- `export-default-config` no longer emits `add_user_details` anywhere.
- `check-config` against chorus-int's `.config` subtree: no new failures.
- Repo-wide grep for `AddUserDetails`/`add_user_details` returns nothing outside this diff.
